### PR TITLE
大量改进

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-vimconfig
 *.swp

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ You can use `$VIM_RESET_GVIMRC` to tell `vim-reset` to use a specific GVIM confi
 
 You can use `$VIM_RESET_VIMRTP` to add addtional VIM runtimepath, which is useful for testing plugins.
 
+You can use `$VIM_RESET_HARD` to tell `vim-reset` to do a _hard_ reset. By default, `vim-reset` will do a _soft_ reset unless this variable is set to 1. That means the VIM variable `runtimepath` will contain `$VIM_RESET_CONFDIR` along with your old `runtimepath`. On the contrary, a _hard_ reset will make sure the VIM variable `runtimepath` only contain the system default setting along with the paths you specified.
+
 You can use `$VIM_RESET_FORCE` to tell `vim-reset` to force re-establishing itself.
 
 You can use `$VIM_RESET_REVERT` to tell `vim-reset` to revert the changes it has made.
 
 You can also add these commands to your `~/.bashrc` file and run `vim-reset` each time you invoke an interactive shell.
-
-NOTE: `vim-reset` will do a _soft_ reset. That means the vim variable `runtimepath` will contain `$VIM_RESET_CONFDIR` along with your old `runtimepath`.
 
 NOTE AGAIN: `vim-reset` uses `$VIM_RESET_CONFDIR/_vimrc` as your main VIM configuration file by default, not `$VIM_RESET_CONFDIR/.vimrc`.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ You can use `$VIM_RESET_GVIMRC` to tell `vim-reset` to use a specific GVIM confi
 
 You can use `$VIM_RESET_VIMRTP` to add addtional VIM runtimepath, which is useful for testing plugins.
 
+You can use `$VIM_RESET_FORCE` to tell `vim-reset` to force re-establishing itself.
+
 You can use `$VIM_RESET_REVERT` to tell `vim-reset` to revert the changes it has made.
 
 You can also add these commands to your `~/.bashrc` file and run `vim-reset` each time you invoke an interactive shell.

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ You may find `vim-reset` similar to [pathogen.vim]( https://github.com/tpope/vim
 ## how to use it?
 
 1. `git clone https://github.com/yegle/vim-reset`
-2. `export VIMCONFIG_DIR="${HOME}/myvimconfigdir"`
+2. `export VIM_RESET_CONFDIR="${HOME}/myvimconfigdir"`
 3. `source vim-reset/activate`
 
-You can put your `~/.vimrc` files and all your plugins/syntax files into `$VIMCONFIG_DIR` now.
+You can put your `~/.vimrc` files and all your plugins/syntax files into `$VIM_RESET_CONFDIR` now.
 
 You can also add these commands to your `~/.bashrc` file and run `vim-reset` each time you invoke an interactive shell.
 
-NOTE: `vim-reset` will do a _soft_ reset. That means the vim variable `runtimepath` will contain `$VIMCONFIG_DIR` along with your old `runtimepath`.
+NOTE: `vim-reset` will do a _soft_ reset. That means the vim variable `runtimepath` will contain `$VIM_RESET_CONFDIR` along with your old `runtimepath`.
 
-NOTE AGAIN: `vim-reset` uses `$VIMCONFIG_DIR/_vimrc` as your main VIM configuration file by default, not `$VIMCONFIG_DIR/.vimrc`.
+NOTE AGAIN: `vim-reset` uses `$VIM_RESET_CONFDIR/_vimrc` as your main VIM configuration file by default, not `$VIM_RESET_CONFDIR/.vimrc`.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ You may find `vim-reset` similar to [pathogen.vim]( https://github.com/tpope/vim
 ## how to use it?
 
 1. `git clone https://github.com/yegle/vim-reset`
-2. `export VIM_RESET_CONFDIR="${HOME}/myvimconfigdir"`
-3. `source vim-reset/activate`
+2. `source vim-reset/activate`
+3. `export VIM_RESET_CONFDIR="${HOME}/myvimconfigdir"`
+4. `vim-reset`
 
 You can put your `~/.vimrc` files and all your plugins/syntax files into `$VIM_RESET_CONFDIR` now.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ You can use `$VIM_RESET_GVIMRC` to tell `vim-reset` to use a specific GVIM confi
 
 You can use `$VIM_RESET_VIMRTP` to add addtional VIM runtimepath, which is useful for testing plugins.
 
+You can use `$VIM_RESET_REVERT` to tell `vim-reset` to revert the changes it has made.
+
 You can also add these commands to your `~/.bashrc` file and run `vim-reset` each time you invoke an interactive shell.
 
 NOTE: `vim-reset` will do a _soft_ reset. That means the vim variable `runtimepath` will contain `$VIM_RESET_CONFDIR` along with your old `runtimepath`.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ You can put your `~/.vimrc` files and all your plugins/syntax files into `$VIM_R
 
 You can use `$VIM_RESET_VIMRC` to tell `vim-reset` to use a specific VIM configuration file.
 
+You can use `$VIM_RESET_GVIMRC` to tell `vim-reset` to use a specific GVIM configuration file.
+
 You can use `$VIM_RESET_VIMRTP` to add addtional VIM runtimepath, which is useful for testing plugins.
 
 You can also add these commands to your `~/.bashrc` file and run `vim-reset` each time you invoke an interactive shell.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vim-reset
 
-A reset script so you can customize your very own VIM configurations.
+A bash script so you can customize your very own VIM configurations.
 
 `vim-reset` is in [Public Domain]( http://en.wikipedia.org/wiki/Public_Domain ), feel free to re-use it and distribute it.
 
@@ -17,7 +17,7 @@ As a system administrator, I have to deal with different distros, each comes wit
 
 ## anything else?
 
-Besides the `reset` process, `vim-reset` also provides a way to maintain your very own VIM configuration files in a different directory other than `~/.vim` directory. 
+Besides the `reset` process, `vim-reset` also provides a way to maintain your very own VIM configuration files in a different directory other than `~/.vim` directory.
 You can put all syntax file, plugins in a dedicated directory without any modification to `~/.vim` directory.
 
 If you are familiar to `python`, `vim-reset` is like the `virtualenv` for VIM.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ You may find `vim-reset` similar to [pathogen.vim]( https://github.com/tpope/vim
 
 You can put your `~/.vimrc` files and all your plugins/syntax files into `$VIM_RESET_CONFDIR` now.
 
+You can use `$VIM_RESET_VIMRC` to tell `vim-reset` to use a specific VIM configuration file.
+
 You can also add these commands to your `~/.bashrc` file and run `vim-reset` each time you invoke an interactive shell.
 
 NOTE: `vim-reset` will do a _soft_ reset. That means the vim variable `runtimepath` will contain `$VIM_RESET_CONFDIR` along with your old `runtimepath`.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ You can put your `~/.vimrc` files and all your plugins/syntax files into `$VIM_R
 
 You can use `$VIM_RESET_VIMRC` to tell `vim-reset` to use a specific VIM configuration file.
 
+You can use `$VIM_RESET_VIMRTP` to add addtional VIM runtimepath, which is useful for testing plugins.
+
 You can also add these commands to your `~/.bashrc` file and run `vim-reset` each time you invoke an interactive shell.
 
 NOTE: `vim-reset` will do a _soft_ reset. That means the vim variable `runtimepath` will contain `$VIM_RESET_CONFDIR` along with your old `runtimepath`.

--- a/README.md
+++ b/README.md
@@ -4,21 +4,17 @@ A bash script so you can customize your very own VIM configurations.
 
 `vim-reset` is in [Public Domain]( http://en.wikipedia.org/wiki/Public_Domain ), feel free to re-use it and distribute it.
 
-*WARNING*:
-`vim-reset` doesn't come with any default `.vimrc` file / syntax file / plugins etc. You can refer to [yegle-vimrc]( https://github.com/yegle/yegle-vimrc ) as a start point.
-
 ## what's reset?
 
-The `reset` concept was borrowed from web front-end engineers.
-It's a good idea to first reset all browser-specific default settings before front-end engineers adding any customization.
+The `reset` concept is borrowed from web front-end engineers. It's a good idea to first reset all browser-specific default settings before front-end engineers adding any customization.
 
 So is `vim-reset`. It is intended to `reset` default VIM settings between different Linux distributions.
-As a system administrator, I have to deal with different distros, each comes with different default VIM settings. That's really annoying.
+
+> As a system administrator, I have to deal with different distros, each comes with different default VIM settings. That's really annoying. -- yegel@github
 
 ## anything else?
 
-Besides the `reset` process, `vim-reset` also provides a way to maintain your very own VIM configuration files in a different directory other than `~/.vim` directory.
-You can put all syntax file, plugins in a dedicated directory without any modification to `~/.vim` directory.
+Besides the reset process, `vim-reset` also provides a way to maintain your very own VIM configuration files in a different directory other than `~/.vim` directory. You can put all syntax files, plugins in a dedicated directory without any modification to `~/.vim` directory.
 
 If you are familiar to `python`, `vim-reset` is like the `virtualenv` for VIM.
 
@@ -30,33 +26,37 @@ Vim hardcoded `~/.vim` directory and `~/.vimrc` file in their source code which 
 
 ## do I need this?
 
-You may find `vim-reset` similar to [pathogen.vim]( https://github.com/tpope/vim-pathogen ). But they are different. `pathogen.vim` manages files _inside_ `runtimepath`, while `vim-reset` take care of your `runtimepath` directory.
+You may find `vim-reset` similar to [pathogen.vim](https://github.com/tpope/vim-pathogen). But they are different. `pathogen.vim` manages files _inside_ `runtimepath`, while `vim-reset` take care of your `runtimepath` directory.
 
 `vim-reset` is very useful if you need to maintain many different sets of vim configuration files, or you are using a shared account on a server with someone else.
 
 `vim-reset` makes it possible to share a complete `vimrc` directory to someone else with all plugins / syntax, not just `~/.vimrc`.
 
+It is also useful for plugin developers, you can customize a very specific 'runtimepath' to test your plugins.
+
 ## how to use it?
 
 1. `git clone https://github.com/yegle/vim-reset`
 2. `source vim-reset/activate`
-3. `export VIM_RESET_CONFDIR="${HOME}/myvimconfigdir"`
-4. `vim-reset`
+3. `vim-reset -h`
 
-You can put your `~/.vimrc` files and all your plugins/syntax files into `$VIM_RESET_CONFDIR` now.
+You can put your `~/.vimrc` files and all your plugins/syntax files into `$VIM_RESET_CONFDIR` now. NOTE: `vim-reset` uses `$VIM_RESET_CONFDIR/_vimrc` as your main VIM configuration file by default, not `$VIM_RESET_CONFDIR/.vimrc`.
 
-You can use `$VIM_RESET_VIMRC` to tell `vim-reset` to use a specific VIM configuration file.
+You can use `--vimrc` option or `$VIM_RESET_VIMRC` env-var to tell `vim-reset` to use a specific VIM configuration file.
 
-You can use `$VIM_RESET_GVIMRC` to tell `vim-reset` to use a specific GVIM configuration file.
+You can use `--gvimrc` option or `$VIM_RESET_GVIMRC` env-var to tell `vim-reset` to use a specific GVIM configuration file.
 
-You can use `$VIM_RESET_VIMRTP` to add addtional VIM runtimepath, which is useful for testing plugins.
+You can use `--add-rtp` option or `$VIM_RESET_VIMRTP` env-var to add addtional VIM runtimepath, which is useful for testing plugins.
 
-You can use `$VIM_RESET_HARD` to tell `vim-reset` to do a _hard_ reset. By default, `vim-reset` will do a _soft_ reset unless this variable is set to 1. That means the VIM variable `runtimepath` will contain `$VIM_RESET_CONFDIR` along with your old `runtimepath`. On the contrary, a _hard_ reset will make sure the VIM variable `runtimepath` only contain the system default setting along with the paths you specified.
+You can use `--hard` option or `$VIM_RESET_HARD` env-var to tell `vim-reset` to do a _hard_ reset. By default, `vim-reset` will do a _soft_ reset unless this variable is set to 1. That means the VIM variable `runtimepath` will contain `$VIM_RESET_CONFDIR` along with your old `runtimepath`. On the contrary, a _hard_ reset will make sure the VIM variable `runtimepath` only contain the system default setting along with the paths you specified.
 
-You can use `$VIM_RESET_FORCE` to tell `vim-reset` to force re-establishing itself.
+You can use `--force` option or `$VIM_RESET_FORCE` env-var to tell `vim-reset` to force re-establishing itself.
 
-You can use `$VIM_RESET_REVERT` to tell `vim-reset` to revert the changes it has made.
+You can use `--revert` option or `$VIM_RESET_REVERT` env-var to tell `vim-reset` to revert the changes it has made.
 
-You can also add these commands to your `~/.bashrc` file and run `vim-reset` each time you invoke an interactive shell.
+You can also add `source vim-reset/activate` to your `~/.bashrc` file, so you have `vim-reset` available each time you invoke an interactive shell.
 
-NOTE AGAIN: `vim-reset` uses `$VIM_RESET_CONFDIR/_vimrc` as your main VIM configuration file by default, not `$VIM_RESET_CONFDIR/.vimrc`.
+# contributors
+
+* [yegel@github](https://github.com/yegle)
+* [techlivezheng@github](https://github.com/techlivezheng)

--- a/activate
+++ b/activate
@@ -31,7 +31,7 @@ del_from_path() {
 # check if vim-reset is already working now
 check_vim_reset() {
     add_to_path "${VIMCONFIG_DIR}/bin"
-    grep -IF 'GENERATED_BY_VIM_RESET' $( which vim ) &>/dev/null
+    grep -IF 'GENERATED_BY_VIM_RESET' "$( which vim )" &>/dev/null
 }
 
 if [[ -z ${VIMCONFIG_DIR} ]]
@@ -70,19 +70,19 @@ VIMRC=${VIMCONFIG_DIR}/_vimrc
 
 if [[ ! -d ${VIMCONFIG_DIR}/bin ]]
 then
-    mkdir ${VIMCONFIG_DIR}/bin
+    mkdir "${VIMCONFIG_DIR}/bin"
 fi
 
 if [[ ! -f ${VIMCONFIG_DIR}/bin/vim ]]
 then
-    cat > ${VIMCONFIG_DIR}/bin/vim <<OUTPUT
+    cat > "${VIMCONFIG_DIR}/bin/vim" <<OUTPUT
 #!/usr/bin/env bash
 # GENERATED_BY_VIM_RESET
 # don't delete the line above
 
-${VIM} --cmd 'set runtimepath=${RUNTIMEPATH}' -u ${VIMRC} \$@
+${VIM} --cmd 'set runtimepath=${RUNTIMEPATH}' -u '${VIMRC}' \$@
 OUTPUT
-    chmod +x ${VIMCONFIG_DIR}/bin/vim
+    chmod +x "${VIMCONFIG_DIR}/bin/vim"
 fi
 
 add_to_path "${VIMCONFIG_DIR}/bin"

--- a/activate
+++ b/activate
@@ -17,15 +17,8 @@ path_pop() {
 # push $1 as the first directory of PATH environment variable
 path_push() {
     local path=$1
-    local -a path_array
-    while read d
-    do
-        if [[ ${path%/} != ${d%/} ]]
-        then
-            path_array=( $( echo ${path_array[*]} ) $d )
-        fi
-    done<<<$( echo $PATH |tr ':' ' ' )
-    export PATH=${path}:$( IFS=":"; echo "${path_array[*]}" )
+    path_pop "${path}"
+    export PATH=${path}:$PATH
 }
 
 # check if vim-reset is already working now

--- a/activate
+++ b/activate
@@ -25,7 +25,7 @@ path_push() {
 get_vim_rtp() {
     ${VIM} 2>/dev/null \
         -c "redir! > /dev/stdout" -c 'set runtimepath' -c 'q' | \
-        tail -n1 | cut -d= -f2- | cut -d, -f2-
+        tail -n1 | cut -d= -f2-
 }
 
 # check if vim-reset is already working now
@@ -68,6 +68,8 @@ else
     VIM_RESET_VIMRTP=${VIM_RESET_CONFDIR}
 fi
 
+VIM_RESET_VIMRTP=${VIM_RESET_VIMRTP},"~/.vim"
+
 declare -a rtps
 IFS=',' read -ra rtps < <(echo ${VIM_RESET_VIMRTP})
 
@@ -93,6 +95,7 @@ do
             unset _rtps[${_rtp_i}]
         }
     done
+    [[ ${rtp} == "~/.vim" ]] && continue
     _rtps=( "${rtp}" "${_rtps[@]}" "${rtp}"/after )
 done
 VIM_RESET_VIMRTP=$( IFS=","; echo "${_rtps[*]}" )

--- a/activate
+++ b/activate
@@ -363,10 +363,6 @@ OUTPUT
 
     [[ ! -e ${gvimrc} ]] && touch "${gvimrc}"
 
-    unset VIM_RESET_VIMRC
-    unset VIM_RESET_GVIMRC
-    unset VIM_RESET_VIMRTP
-
     return 0
 }
 

--- a/activate
+++ b/activate
@@ -159,14 +159,14 @@ vim_reset() {
                 shift
             ;;
             --confdir )
-                VIM_RESET_CONFDIR=$2
+                VIM_RESET_CONFDIR=${2%/}
                 shift
             ;;
             --add-rtp )
                 [[ -z ${VIM_RESET_VIMRTP} ]] && {
-                    VIM_RESET_VIMRTP=$2
+                    VIM_RESET_VIMRTP=${2%/}
                 } || {
-                    VIM_RESET_VIMRTP=${VIM_RESET_VIMRTP},$2
+                    VIM_RESET_VIMRTP=${VIM_RESET_VIMRTP},${2%/}
                 }
                 shift
             ;;

--- a/activate
+++ b/activate
@@ -52,6 +52,7 @@ A bash script so you can customize your very own VIM configurations.
 Usage:
 
     vim-reset [-h|--help] \
+              [--vimrc VIM_RESET_VIMRC] \
               [--confdir VIM_RESET_CONFDIR] \
               [--add-rtp ADDITIONAL_RTP_PATH] ..
 
@@ -59,6 +60,11 @@ Options:
 
     -h, --help
         Show this help information.
+
+    --vimrc VIM_RESET_VIMRC
+        VIM configuration file to be used.
+        If both this option and env-viriable 'VIM_RESET_VIMRC' are
+        set, the value of this option will be used.
 
     --confdir VIM_RESET_CONFDIR
         The main runtimepath of VIM after the resetting.
@@ -103,6 +109,10 @@ vim_reset() {
             -h | --help )
                 show_help
                 return 0
+            ;;
+            --vimrc )
+                VIM_RESET_VIMRC=$2
+                shift
             ;;
             --confdir )
                 VIM_RESET_CONFDIR=$2

--- a/activate
+++ b/activate
@@ -6,7 +6,7 @@ add_to_path() {
     local -a path_array
     while read d
     do
-        if [[ ${path} != ${d} ]]
+        if [[ ${path%/} != ${d%/} ]]
         then
             path_array=( $( echo ${path_array[*]} ) $d )
         fi
@@ -20,7 +20,7 @@ del_from_path() {
     local -a path_array
     while read d
     do
-        if [[ ${path} != ${d} ]]
+        if [[ ${path%/} != ${d%/} ]]
         then
             path_array=( $( echo ${path_array[*]} ) $d )
         fi

--- a/activate
+++ b/activate
@@ -1,55 +1,51 @@
 #!/usr/bin/env bash
 
 # add $1 as the first directory of PATH environment variable
-function add_to_path {
+add_to_path() {
     local mypath=$1
     local -a path_array
     while read d
     do
-        if [[ "$VIMCONFIG_DIR" != "${d}" ]]
+        if [[ "${VIMCONFIG_DIR}" != "${d}" ]]
         then
             path_array=( $( echo ${path_array[*]} ) $d )
         fi
     done<<<$( echo $PATH |tr ':' ' ' )
-    new_path="$( IFS=":"; echo "${path_array[*]}" )"
-    export PATH="${mypath}:${new_path}"
+    export PATH="${mypath}:$( IFS=":"; echo "${path_array[*]}" )"
 }
 
-# delete $1 from PATH environment variable 
-function del_from_path {
+# delete $1 from PATH environment variable
+del_from_path() {
     local mypath=$1
     local -a path_array
     while read d
     do
-        if [[ "$VIMCONFIG_DIR" != "${d}" ]]
+        if [[ "${VIMCONFIG_DIR}" != "${d}" ]]
         then
             path_array=( $( echo ${path_array[*]} ) $d )
         fi
     done<<<$( echo $PATH |tr ':' ' ' )
-    new_path="$( IFS=":"; echo "${path_array[*]}" )"
-    export PATH=$new_path
+    export PATH="$( IFS=":"; echo "${path_array[*]}" )"
 }
 
 # check if vim-reset is already working now
-function check_vim_reset {
+check_vim_reset() {
     add_to_path "${VIMCONFIG_DIR}/bin"
     grep -IF 'GENERATED_BY_VIM_RESET' $( which vim ) &>/dev/null
-    return $?
 }
 
-if [[ "$VIMCONFIG_DIR" == "" ]]
+if [[ -z "${VIMCONFIG_DIR}" ]]
 then
     # this is a common one-liner copied from
     # http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
-    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" 
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
     VIMCONFIG_DIR="${SCRIPT_DIR}/vimconfig"
     echo "You didn't specify VIMCONFIG_DIR environment, default using ${VIMCONFIG_DIR}" >&2
 else
     echo "Using ${VIMCONFIG_DIR}" >&2
 fi
 
-check_vim_reset
-if [[ $? -eq 0 ]]
+if check_vim_reset
 then
     return
 fi
@@ -65,11 +61,11 @@ del_from_path "${VIMCONFIG_DIR}/bin"
 TEMP=$( mktemp )
 VIM=$( which vim )
 
-$VIM -c "redir! > $TEMP" -c 'set runtimepath' -c 'q'
+${VIM} -c "redir! > $TEMP" -c 'set runtimepath' -c 'q'
 
 OLD_RUNTIMEPATH=$( tail -n1 $TEMP | awk -F= '{print $2}' | cut -d, -f2- )
 
-RUNTIMEPATH="$VIMCONFIG_DIR,$OLD_RUNTIMEPATH"
+RUNTIMEPATH="${VIMCONFIG_DIR},${OLD_RUNTIMEPATH}"
 VIMRC="${VIMCONFIG_DIR}/_vimrc"
 
 if [[ ! -d "${VIMCONFIG_DIR}/bin" ]]
@@ -84,7 +80,7 @@ then
 # GENERATED_BY_VIM_RESET
 # don't delete the line above
 
-$VIM --cmd 'set runtimepath=${RUNTIMEPATH}' -u ${VIMRC} \$@
+${VIM} --cmd 'set runtimepath=${RUNTIMEPATH}' -u ${VIMRC} \$@
 OUTPUT
     chmod +x ${VIMCONFIG_DIR}/bin/vim
 fi
@@ -95,9 +91,10 @@ echo "========================"
 echo "VIMRC=${VIMRC}"
 echo "VIMRUNTIME=${RUNTIMEPATH}"
 echo "========================"
-echo ""
 
 if [[ ! -f "${VIMRC}" ]]
 then
+    echo
     echo "WARNING: ${VIMRC} doesn't exist, please remember to create it or copy your current ~/.vimrc file" >&2
+    echo
 fi

--- a/activate
+++ b/activate
@@ -57,6 +57,11 @@ if [[ ! -d ${VIM_RESET_CONFDIR} ]]
 then
     echo "Creating ${VIM_RESET_CONFDIR}" >&2
     mkdir -p "${VIM_RESET_CONFDIR}"
+    [[ $? -ne 0 ]] && {
+        echo "Fail to mkdir ${VIM_RESET_CONFDIR}"
+        echo "Aborting..."
+        return
+    }
 fi
 
 if [[ -z ${VIM_RESET_VIMRC} ]]
@@ -106,6 +111,11 @@ VIM_RESET_VIMRTP=$( IFS=","; echo "${_rtps[*]}" )
 if [[ ! -d ${VIM_RESET_CONFDIR}/bin ]]
 then
     mkdir "${VIM_RESET_CONFDIR}/bin"
+    [[ $? -ne 0 ]] && {
+        echo "Fail to mkdir ${VIM_RESET_CONFDIR}/bin"
+        echo "Aborting..."
+        return
+    }
 fi
 
 if [[ ! -f ${VIM_RESET_CONFDIR}/bin/vim ]]

--- a/activate
+++ b/activate
@@ -2,7 +2,7 @@
 
 # add $1 as the first directory of PATH environment variable
 add_to_path() {
-    local mypath=$1
+    local path=$1
     local -a path_array
     while read d
     do
@@ -11,12 +11,12 @@ add_to_path() {
             path_array=( $( echo ${path_array[*]} ) $d )
         fi
     done<<<$( echo $PATH |tr ':' ' ' )
-    export PATH=${mypath}:$( IFS=":"; echo "${path_array[*]}" )
+    export PATH=${path}:$( IFS=":"; echo "${path_array[*]}" )
 }
 
 # delete $1 from PATH environment variable
 del_from_path() {
-    local mypath=$1
+    local path=$1
     local -a path_array
     while read d
     do

--- a/activate
+++ b/activate
@@ -44,7 +44,55 @@ normalize() {
   pwd
 }
 
+show_help() {
+    cat << 'EOF'
+
+A bash script so you can customize your very own VIM configurations.
+
+Usage:
+
+    vim-reset [-h|--help]
+
+Options:
+
+    -h, --help
+        Show this help information.
+
+Environment Variables:
+
+
+    * `VIM_RESET_CONFDIR`
+        Required.
+        The main runtimepath of VIM after the resetting.
+
+    * `VIM_RESET_VIMRC`
+        Optional, default is '$VIM_RESET_CONFDIR/_vimrc'
+        VIM configuration file to be used.
+
+    * `VIM_RESET_GVIMRC`
+        Optional, default is '$VIM_RESET_CONFDIR/_gvimrc'
+        GVIM configuration file to be used.
+
+    * `VIM_RESET_VIMRTP`
+        Optional.
+        Comma separated directory paths, used as the VIM's 'rtp'
+        after the resetting. It is useful for testing plugins.
+
+EOF
+}
+
 vim_reset() {
+    while [ $# -gt 0 ]
+    do
+        case $1 in
+            -h | --help )
+                show_help
+                return 0
+            ;;
+        esac
+        shift
+    done
+
     if check_vim_reset
     then
         return 1

--- a/activate
+++ b/activate
@@ -139,17 +139,12 @@ else
     return 1
 fi
 
+[[ ! -e ${VIM_RESET_VIMRC} ]] && touch "${VIM_RESET_VIMRC}"
+
 echo "========================"
 echo "VIMRC=${VIM_RESET_VIMRC}"
 echo "VIMRTP=${VIM_RESET_VIMRTP}"
 echo "========================"
-
-if [[ ! -f ${VIM_RESET_VIMRC} ]]
-then
-    echo
-    echo "WARNING: ${VIM_RESET_VIMRC} doesn't exist, please remember to create it or copy your current ~/.vimrc file" >&2
-    echo
-fi
 
 unset VIM_RESET_VIMRC
 unset VIM_RESET_VIMRTP

--- a/activate
+++ b/activate
@@ -35,20 +35,20 @@ check_vim_reset() {
 
 if check_vim_reset
 then
-    return
+    return 1
 fi
 
 VIM=$( which vim )
 [[ -z ${VIM} ]] && {
     echo "No VIM installed?"
-    return
+    return 1
 }
 
 if [[ -z ${VIM_RESET_CONFDIR} ]]
 then
     echo "Env-variable 'VIM_RESET_CONFDIR' has to be set" >&2
     echo "Aborting..."
-    return
+    return 1
 else
     echo "Using ${VIM_RESET_CONFDIR}" >&2
 fi
@@ -60,7 +60,7 @@ then
     [[ $? -ne 0 ]] && {
         echo "Fail to mkdir ${VIM_RESET_CONFDIR}"
         echo "Aborting..."
-        return
+        return 1
     }
 fi
 
@@ -114,7 +114,7 @@ then
     [[ $? -ne 0 ]] && {
         echo "Fail to mkdir ${VIM_RESET_CONFDIR}/bin"
         echo "Aborting..."
-        return
+        return 1
     }
 fi
 
@@ -136,7 +136,7 @@ then
 else
     echo "Something odd has happend, please check your ${VIM_RESET_CONFDIR}"
     echo "Aborting..."
-    return
+    return 1
 fi
 
 echo "========================"

--- a/activate
+++ b/activate
@@ -71,7 +71,9 @@ fi
 declare -a rtps
 IFS=',' read -ra rtps < <(echo ${VIM_RESET_VIMRTP})
 
-VIM_RESET_VIMRTP=$(get_vim_rtp)
+declare -a _rtps
+IFS=',' read -ra _rtps < <(get_vim_rtp)
+
 for rtp_i in ${!rtps[*]}
 do
     # Preserve the exact order of the rtps
@@ -80,8 +82,20 @@ do
     # Skip non-directory path
     [[ -d ${rtp} ]] || continue
 
-    VIM_RESET_VIMRTP=${rtp},${VIM_RESET_VIMRTP},${rtp}/after
+    # Remove duplicate paths
+    for _rtp_i in ${!_rtps[*]}
+    do
+        _rtp=${_rtps[${_rtp_i}]}
+        {
+            [[ ${rtp%/} == ${_rtp%/} ]] || \
+                [[ ${rtp%/}/after == ${_rtp%/}/after ]]
+        } && {
+            unset _rtps[${_rtp_i}]
+        }
+    done
+    _rtps=( "${rtp}" "${_rtps[@]}" "${rtp}"/after )
 done
+VIM_RESET_VIMRTP=$( IFS=","; echo "${_rtps[*]}" )
 
 if [[ ! -d ${VIM_RESET_CONFDIR}/bin ]]
 then

--- a/activate
+++ b/activate
@@ -44,6 +44,11 @@ VIM=$( which vim )
     return 1
 }
 
+GVIM=$( which gvim )
+[[ -z ${GVIM} ]] && {
+    GVIM=${VIM}
+}
+
 if [[ -z ${VIM_RESET_CONFDIR} ]]
 then
     echo "Env-variable 'VIM_RESET_CONFDIR' has to be set" >&2
@@ -67,6 +72,11 @@ fi
 if [[ -z ${VIM_RESET_VIMRC} ]]
 then
     VIM_RESET_VIMRC=${VIM_RESET_CONFDIR}/_vimrc
+fi
+
+if [[ -z ${VIM_RESET_GVIMRC} ]]
+then
+    VIM_RESET_GVIMRC=${VIM_RESET_CONFDIR}/_gvimrc
 fi
 
 if [[ -n ${VIM_RESET_VIMRTP} ]]
@@ -130,6 +140,18 @@ OUTPUT
     chmod +x "${VIM_RESET_CONFDIR}/bin/vim"
 fi
 
+if [[ ! -e ${VIM_RESET_CONFDIR}/bin/gvim ]]
+then
+    cat > "${VIM_RESET_CONFDIR}/bin/gvim" <<OUTPUT
+#!/usr/bin/env bash
+# GENERATED_BY_VIM_RESET
+# don't delete the line above
+
+${GVIM} --cmd 'set runtimepath=${VIMRTP}' -u '${VIMRC}' -U '${VIM_RESET_GVIMRC}' \$@
+OUTPUT
+    chmod +x "${VIM_RESET_CONFDIR}/bin/gvim"
+fi
+
 if [[ -f ${VIM_RESET_CONFDIR}/bin/vim ]] && [[ -x ${VIM_RESET_CONFDIR}/bin/vim ]]
 then
     path_push "${VIM_RESET_CONFDIR}/bin"
@@ -140,11 +162,14 @@ else
 fi
 
 [[ ! -e ${VIM_RESET_VIMRC} ]] && touch "${VIM_RESET_VIMRC}"
+[[ ! -e ${VIM_RESET_GVIMRC} ]] && touch "${VIM_RESET_GVIMRC}"
 
 echo "========================"
 echo "VIMRC=${VIM_RESET_VIMRC}"
+echo "GVIMRC=${VIM_RESET_GVIMRC}"
 echo "VIMRTP=${VIM_RESET_VIMRTP}"
 echo "========================"
 
 unset VIM_RESET_VIMRC
+unset VIM_RESET_GVIMRC
 unset VIM_RESET_VIMRTP

--- a/activate
+++ b/activate
@@ -94,6 +94,7 @@ vim_reset() {
     declare -a _rtps
     IFS=',' read -ra _rtps < <(get_vim_rtp)
 
+    local rtp rtp_i _rtp _rtp_i
     for rtp_i in ${!rtps[*]}
     do
         # Preserve the exact order of the rtps

--- a/activate
+++ b/activate
@@ -182,7 +182,7 @@ do
         _rtp=${_rtps[${_rtp_i}]}
         {
             [[ ${rtp%/} == ${_rtp%/} ]] || \
-                [[ ${rtp%/}/after == ${_rtp%/}/after ]]
+                [[ ${rtp%/}/after == ${_rtp%/} ]]
         } && {
             unset _rtps[${_rtp_i}]
         }

--- a/activate
+++ b/activate
@@ -62,6 +62,9 @@ Options:
     -h, --help
         Show this help information.
 
+        --hard
+        Do a hard reset, use only the given rtps.
+
     -f, --force
         Force re-establishing the 'vim-reset'.
 
@@ -111,6 +114,10 @@ Environment Variables:
         Comma separated directory paths, used as the VIM's 'rtp'
         after the resetting. It is useful for testing plugins.
 
+    * `VIM_RESET_HARD`
+        Optional.
+        Do a hard reset, use only the given rtps.
+
     * `VIM_RESET_FORCE`
         Optional.
         Force re-establishing the 'vim-reset'.
@@ -123,6 +130,7 @@ EOF
 }
 
 vim_reset() {
+    declare -i hard=${VIM_RESET_HARD:-0}
     declare -i force=${VIM_RESET_FORCE:-0}
     declare -i revert=${VIM_RESET_REVERT:-0}
 
@@ -132,6 +140,9 @@ vim_reset() {
             -h | --help )
                 show_help
                 return 0
+            ;;
+                 --hard )
+                hard=1
             ;;
             -f | --force )
                 force=1
@@ -350,9 +361,16 @@ vim_revert() {
 }
 
 get_vim_rtp() {
-    ${VIM} 2>/dev/null \
-        -c "redir! > /dev/stdout" -c 'set runtimepath' -c 'q' | \
-        tail -n1 | cut -d= -f2-
+    if [[ ${hard} -ne 1 ]]
+    then
+        ${VIM} 2>/dev/null \
+            -c "redir! > /dev/stdout" -c 'set runtimepath' -c 'q' | \
+            tail -n1 | cut -d= -f2-
+    else
+        ${VIM} 2>/dev/null -u NONE \
+            -c "redir! > /dev/stdout" -c 'set runtimepath' -c 'q' | \
+            tail -n1 | cut -d= -f2-
+    fi
 }
 
 # check if vim-reset is already working now

--- a/activate
+++ b/activate
@@ -36,11 +36,9 @@ check_vim_reset() {
 
 if [[ -z ${VIM_RESET_CONFDIR} ]]
 then
-    # this is a common one-liner copied from
-    # http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
-    SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-    VIM_RESET_CONFDIR=${SCRIPT_DIR}/vimconfig
-    echo "You didn't specify VIM_RESET_CONFDIR environment, default using ${VIM_RESET_CONFDIR}" >&2
+    echo "Env-variable 'VIM_RESET_CONFDIR' has to be set" >&2
+    echo "Aborting..."
+    return
 else
     echo "Using ${VIM_RESET_CONFDIR}" >&2
 fi

--- a/activate
+++ b/activate
@@ -52,7 +52,8 @@ A bash script so you can customize your very own VIM configurations.
 Usage:
 
     vim-reset [-h|--help] \
-              [--confdir VIM_RESET_CONFDIR]
+              [--confdir VIM_RESET_CONFDIR] \
+              [--add-rtp ADDITIONAL_RTP_PATH] ..
 
 Options:
 
@@ -64,6 +65,13 @@ Options:
         Either this option or env-variable 'VIM_RESET_CONFDIR' has
         to been set. If they are both set, the value of this option
         will be used.
+
+    --add-rtp ADDITIONAL_RTP_PATH
+        Additional VIM runtimepath. This option could be specified
+        multiple times to form a set of runtimepaths, the order will
+        be preserverd in the final VIM's 'rtp' setting. If env-variable
+        'VIM_RESET_VIMRTP' has also been set, the value of this option
+        will be appended.
 
 Environment Variables:
 
@@ -98,6 +106,14 @@ vim_reset() {
             ;;
             --confdir )
                 VIM_RESET_CONFDIR=$2
+                shift
+            ;;
+            --add-rtp )
+                [[ -z ${VIM_RESET_VIMRTP} ]] && {
+                    VIM_RESET_VIMRTP=$2
+                } || {
+                    VIM_RESET_VIMRTP=${VIM_RESET_VIMRTP},$2
+                }
                 shift
             ;;
         esac

--- a/activate
+++ b/activate
@@ -56,12 +56,12 @@ fi
 
 VIM=$( which vim )
 
-RUNTIMEPATH=${VIM_RESET_CONFDIR},$(get_vim_rtp)
-
 if [[ -z ${VIM_RESET_VIMRC} ]]
 then
     VIM_RESET_VIMRC=${VIM_RESET_CONFDIR}/_vimrc
 fi
+
+VIM_RESET_VIMRTP=${VIM_RESET_CONFDIR},$(get_vim_rtp)
 
 if [[ ! -d ${VIM_RESET_CONFDIR}/bin ]]
 then
@@ -75,7 +75,7 @@ then
 # GENERATED_BY_VIM_RESET
 # don't delete the line above
 
-${VIM} --cmd 'set runtimepath=${RUNTIMEPATH}' -u '${VIM_RESET_VIMRC}' \$@
+${VIM} --cmd 'set runtimepath=${VIM_RESET_VIMRTP}' -u '${VIM_RESET_VIMRC}' \$@
 OUTPUT
     chmod +x "${VIM_RESET_CONFDIR}/bin/vim"
 fi
@@ -84,7 +84,7 @@ path_push "${VIM_RESET_CONFDIR}/bin"
 
 echo "========================"
 echo "VIMRC=${VIM_RESET_VIMRC}"
-echo "VIMRUNTIME=${RUNTIMEPATH}"
+echo "VIMRTP=${VIM_RESET_VIMRTP}"
 echo "========================"
 
 if [[ ! -f ${VIM_RESET_VIMRC} ]]

--- a/activate
+++ b/activate
@@ -30,19 +30,19 @@ get_vim_rtp() {
 
 # check if vim-reset is already working now
 check_vim_reset() {
-    path_push "${VIMCONFIG_DIR}/bin"
+    path_push "${VIM_RESET_CONFDIR}/bin"
     grep -IF 'GENERATED_BY_VIM_RESET' "$( which vim )" &>/dev/null
 }
 
-if [[ -z ${VIMCONFIG_DIR} ]]
+if [[ -z ${VIM_RESET_CONFDIR} ]]
 then
     # this is a common one-liner copied from
     # http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
     SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-    VIMCONFIG_DIR=${SCRIPT_DIR}/vimconfig
-    echo "You didn't specify VIMCONFIG_DIR environment, default using ${VIMCONFIG_DIR}" >&2
+    VIM_RESET_CONFDIR=${SCRIPT_DIR}/vimconfig
+    echo "You didn't specify VIM_RESET_CONFDIR environment, default using ${VIM_RESET_CONFDIR}" >&2
 else
-    echo "Using ${VIMCONFIG_DIR}" >&2
+    echo "Using ${VIM_RESET_CONFDIR}" >&2
 fi
 
 if check_vim_reset
@@ -50,35 +50,35 @@ then
     return
 fi
 
-if [[ ! -d ${VIMCONFIG_DIR} ]]
+if [[ ! -d ${VIM_RESET_CONFDIR} ]]
 then
-    echo "Creating ${VIMCONFIG_DIR}" >&2
-    mkdir -p "${VIMCONFIG_DIR}"
+    echo "Creating ${VIM_RESET_CONFDIR}" >&2
+    mkdir -p "${VIM_RESET_CONFDIR}"
 fi
 
 VIM=$( which vim )
 
-RUNTIMEPATH=${VIMCONFIG_DIR},$(get_vim_rtp)
-VIMRC=${VIMCONFIG_DIR}/_vimrc
+RUNTIMEPATH=${VIM_RESET_CONFDIR},$(get_vim_rtp)
+VIMRC=${VIM_RESET_CONFDIR}/_vimrc
 
-if [[ ! -d ${VIMCONFIG_DIR}/bin ]]
+if [[ ! -d ${VIM_RESET_CONFDIR}/bin ]]
 then
-    mkdir "${VIMCONFIG_DIR}/bin"
+    mkdir "${VIM_RESET_CONFDIR}/bin"
 fi
 
-if [[ ! -f ${VIMCONFIG_DIR}/bin/vim ]]
+if [[ ! -f ${VIM_RESET_CONFDIR}/bin/vim ]]
 then
-    cat > "${VIMCONFIG_DIR}/bin/vim" <<OUTPUT
+    cat > "${VIM_RESET_CONFDIR}/bin/vim" <<OUTPUT
 #!/usr/bin/env bash
 # GENERATED_BY_VIM_RESET
 # don't delete the line above
 
 ${VIM} --cmd 'set runtimepath=${RUNTIMEPATH}' -u '${VIMRC}' \$@
 OUTPUT
-    chmod +x "${VIMCONFIG_DIR}/bin/vim"
+    chmod +x "${VIM_RESET_CONFDIR}/bin/vim"
 fi
 
-path_push "${VIMCONFIG_DIR}/bin"
+path_push "${VIM_RESET_CONFDIR}/bin"
 
 echo "========================"
 echo "VIMRC=${VIMRC}"

--- a/activate
+++ b/activate
@@ -56,8 +56,6 @@ then
     mkdir -p "${VIMCONFIG_DIR}"
 fi
 
-del_from_path "${VIMCONFIG_DIR}/bin"
-
 TEMP=$( mktemp )
 VIM=$( which vim )
 

--- a/activate
+++ b/activate
@@ -232,12 +232,20 @@ vim_reset() {
         echo "Using ${VIM_RESET_CONFDIR}" >&2
     fi
 
+    if [[ ${force} -eq 1 ]] && [[ -f ${VIM_RESET_CONFDIR}/bin/vim ]] || [[ ! -e ${VIM_RESET_CONFDIR}/bin/vim ]]
+    then
+        vim_deploy || return $?
+    elif [[ ${force} -ne 1 ]] && [[ -f ${VIM_RESET_CONFDIR}/bin/vim ]] && [[ -x ${VIM_RESET_CONFDIR}/bin/vim ]]
+    then
+        echo "Use an existing vim-reset facility, ${VIM_RESET_CONFDIR}/bin"
+    fi
+
     vim_hijack || return $?
 
     return 0
 }
 
-vim_hijack() {
+vim_deploy() {
     VIM=$( which vim )
     [[ -z ${VIM} ]] && {
         echo "No VIM installed?"
@@ -325,10 +333,7 @@ vim_hijack() {
         }
     fi
 
-    if [[ ! -e ${VIM_RESET_CONFDIR}/bin/vim ]] || \
-        [[ -f ${VIM_RESET_CONFDIR}/bin/vim ]] && [[ ${force} -eq 1 ]]
-    then
-        cat > "${VIM_RESET_CONFDIR}/bin/vim" <<OUTPUT
+    cat > "${VIM_RESET_CONFDIR}/bin/vim" <<OUTPUT
 #!/usr/bin/env bash
 # GENERATED_BY_VIM_RESET
 # don't delete the line above
@@ -336,15 +341,11 @@ vim_hijack() {
 ${VIM} --cmd 'set runtimepath=${VIM_RESET_VIMRTP}' -u '${VIM_RESET_VIMRC}' \$@
 OUTPUT
 
-        chmod +x "${VIM_RESET_CONFDIR}/bin/vim"
+    chmod +x "${VIM_RESET_CONFDIR}/bin/vim"
 
-        [[ ! -e ${VIM_RESET_VIMRC} ]] && touch "${VIM_RESET_VIMRC}"
-    fi
+    [[ ! -e ${VIM_RESET_VIMRC} ]] && touch "${VIM_RESET_VIMRC}"
 
-    if [[ ! -e ${VIM_RESET_CONFDIR}/bin/gvim ]] || \
-        [[ -f ${VIM_RESET_CONFDIR}/bin/gvim ]] && [[ ${force} -eq 1 ]]
-    then
-        cat > "${VIM_RESET_CONFDIR}/bin/gvim" <<OUTPUT
+    cat > "${VIM_RESET_CONFDIR}/bin/gvim" <<OUTPUT
 #!/usr/bin/env bash
 # GENERATED_BY_VIM_RESET
 # don't delete the line above
@@ -352,11 +353,18 @@ OUTPUT
 ${GVIM} --cmd 'set runtimepath=${VIM_RESET_VIMRTP}' -u '${VIM_RESET_VIMRC}' -U '${VIM_RESET_GVIMRC}' \$@
 OUTPUT
 
-        chmod +x "${VIM_RESET_CONFDIR}/bin/gvim"
+    chmod +x "${VIM_RESET_CONFDIR}/bin/gvim"
 
-        [[ ! -e ${VIM_RESET_GVIMRC} ]] && touch "${VIM_RESET_GVIMRC}"
-    fi
+    [[ ! -e ${VIM_RESET_GVIMRC} ]] && touch "${VIM_RESET_GVIMRC}"
 
+    unset VIM_RESET_VIMRC
+    unset VIM_RESET_GVIMRC
+    unset VIM_RESET_VIMRTP
+
+    return 0
+}
+
+vim_hijack() {
     if [[ -f ${VIM_RESET_CONFDIR}/bin/vim ]] && [[ -x ${VIM_RESET_CONFDIR}/bin/vim ]]
     then
         path_push "${VIM_RESET_CONFDIR}/bin"
@@ -365,10 +373,6 @@ OUTPUT
         echo "Aborting..."
         return 1
     fi
-
-    unset VIM_RESET_VIMRC
-    unset VIM_RESET_GVIMRC
-    unset VIM_RESET_VIMRTP
 
     return 0
 }

--- a/activate
+++ b/activate
@@ -44,6 +44,69 @@ normalize() {
   pwd
 }
 
+hijack_vim() {
+    if [[ ! -d ${VIM_RESET_CONFDIR} ]]
+    then
+        echo "Creating ${VIM_RESET_CONFDIR}" >&2
+        mkdir -p "${VIM_RESET_CONFDIR}"
+        [[ $? -ne 0 ]] && {
+            echo "Fail to mkdir ${VIM_RESET_CONFDIR}"
+            echo "Aborting..."
+            return 1
+        }
+    fi
+
+    if [[ ! -d ${VIM_RESET_CONFDIR}/bin ]]
+    then
+        mkdir "${VIM_RESET_CONFDIR}/bin"
+        [[ $? -ne 0 ]] && {
+            echo "Fail to mkdir ${VIM_RESET_CONFDIR}/bin"
+            echo "Aborting..."
+            return 1
+        }
+    fi
+
+    if [[ ! -e ${VIM_RESET_CONFDIR}/bin/vim ]]
+    then
+        cat > "${VIM_RESET_CONFDIR}/bin/vim" <<OUTPUT
+#!/usr/bin/env bash
+# GENERATED_BY_VIM_RESET
+# don't delete the line above
+
+${VIM} --cmd 'set runtimepath=${VIM_RESET_VIMRTP}' -u '${VIM_RESET_VIMRC}' \$@
+OUTPUT
+        chmod +x "${VIM_RESET_CONFDIR}/bin/vim"
+    fi
+
+    if [[ ! -e ${VIM_RESET_CONFDIR}/bin/gvim ]]
+    then
+        cat > "${VIM_RESET_CONFDIR}/bin/gvim" <<OUTPUT
+#!/usr/bin/env bash
+# GENERATED_BY_VIM_RESET
+# don't delete the line above
+
+${GVIM} --cmd 'set runtimepath=${VIM_RESET_VIMRTP}' -u '${VIM_RESET_VIMRC}' -U '${VIM_RESET_GVIMRC}' \$@
+OUTPUT
+        chmod +x "${VIM_RESET_CONFDIR}/bin/gvim"
+    fi
+
+    if [[ -f ${VIM_RESET_CONFDIR}/bin/vim ]] && [[ -x ${VIM_RESET_CONFDIR}/bin/vim ]]
+    then
+        path_push "${VIM_RESET_CONFDIR}/bin"
+    else
+        echo "Something odd has happend, please check ${VIM_RESET_CONFDIR}/bin/vim"
+        echo "Aborting..."
+        return 1
+    fi
+
+    [[ ! -e ${VIM_RESET_VIMRC} ]] && touch "${VIM_RESET_VIMRC}"
+    [[ ! -e ${VIM_RESET_GVIMRC} ]] && touch "${VIM_RESET_GVIMRC}"
+
+    unset VIM_RESET_VIMRC
+    unset VIM_RESET_GVIMRC
+    unset VIM_RESET_VIMRTP
+}
+
 get_vim_rtp() {
     ${VIM} 2>/dev/null \
         -c "redir! > /dev/stdout" -c 'set runtimepath' -c 'q' | \
@@ -78,17 +141,6 @@ then
     return 1
 else
     echo "Using ${VIM_RESET_CONFDIR}" >&2
-fi
-
-if [[ ! -d ${VIM_RESET_CONFDIR} ]]
-then
-    echo "Creating ${VIM_RESET_CONFDIR}" >&2
-    mkdir -p "${VIM_RESET_CONFDIR}"
-    [[ $? -ne 0 ]] && {
-        echo "Fail to mkdir ${VIM_RESET_CONFDIR}"
-        echo "Aborting..."
-        return 1
-    }
 fi
 
 if [[ -z ${VIM_RESET_VIMRC} ]]
@@ -140,58 +192,10 @@ do
 done
 VIM_RESET_VIMRTP=$( IFS=","; echo "${_rtps[*]}" )
 
-if [[ ! -d ${VIM_RESET_CONFDIR}/bin ]]
-then
-    mkdir "${VIM_RESET_CONFDIR}/bin"
-    [[ $? -ne 0 ]] && {
-        echo "Fail to mkdir ${VIM_RESET_CONFDIR}/bin"
-        echo "Aborting..."
-        return 1
-    }
-fi
-
-if [[ ! -e ${VIM_RESET_CONFDIR}/bin/vim ]]
-then
-    cat > "${VIM_RESET_CONFDIR}/bin/vim" <<OUTPUT
-#!/usr/bin/env bash
-# GENERATED_BY_VIM_RESET
-# don't delete the line above
-
-${VIM} --cmd 'set runtimepath=${VIM_RESET_VIMRTP}' -u '${VIM_RESET_VIMRC}' \$@
-OUTPUT
-    chmod +x "${VIM_RESET_CONFDIR}/bin/vim"
-fi
-
-if [[ ! -e ${VIM_RESET_CONFDIR}/bin/gvim ]]
-then
-    cat > "${VIM_RESET_CONFDIR}/bin/gvim" <<OUTPUT
-#!/usr/bin/env bash
-# GENERATED_BY_VIM_RESET
-# don't delete the line above
-
-${GVIM} --cmd 'set runtimepath=${VIMRTP}' -u '${VIMRC}' -U '${VIM_RESET_GVIMRC}' \$@
-OUTPUT
-    chmod +x "${VIM_RESET_CONFDIR}/bin/gvim"
-fi
-
-if [[ -f ${VIM_RESET_CONFDIR}/bin/vim ]] && [[ -x ${VIM_RESET_CONFDIR}/bin/vim ]]
-then
-    path_push "${VIM_RESET_CONFDIR}/bin"
-else
-    echo "Something odd has happend, please check your ${VIM_RESET_CONFDIR}"
-    echo "Aborting..."
-    return 1
-fi
-
-[[ ! -e ${VIM_RESET_VIMRC} ]] && touch "${VIM_RESET_VIMRC}"
-[[ ! -e ${VIM_RESET_GVIMRC} ]] && touch "${VIM_RESET_GVIMRC}"
-
 echo "========================"
 echo "VIMRC=${VIM_RESET_VIMRC}"
 echo "GVIMRC=${VIM_RESET_GVIMRC}"
 echo "VIMRTP=${VIM_RESET_VIMRTP}"
 echo "========================"
 
-unset VIM_RESET_VIMRC
-unset VIM_RESET_GVIMRC
-unset VIM_RESET_VIMRTP
+hijack_vim || return 1

--- a/activate
+++ b/activate
@@ -3,14 +3,15 @@
 # pop $1 from PATH environment variable
 path_pop() {
     local path=$1
-    local -a path_array
-    while read d
+    local path_array
+    local path_index
+    IFS=':' read -ra path_array <<< "$PATH"
+    for path_index in ${!path_array[*]}
     do
-        if [[ ${path%/} != ${d%/} ]]
-        then
-            path_array=( $( echo ${path_array[*]} ) $d )
-        fi
-    done<<<$( echo $PATH |tr ':' ' ' )
+        [[ ${path%/} == ${path_array[${path_index}]%/} ]] && {
+            unset path_array[${path_index}]
+        }
+    done
     export PATH=$( IFS=":"; echo "${path_array[*]}" )
 }
 

--- a/activate
+++ b/activate
@@ -390,7 +390,7 @@ vim_hijack() {
 vim_revert() {
     while grep -IF 'GENERATED_BY_VIM_RESET' "$( which vim )" &>/dev/null
     do
-        path_pop "$( dirname $( which vim ) )"
+        path_pop "$( dirname "$( which vim )" )"
     done
 
     return 0

--- a/activate
+++ b/activate
@@ -6,7 +6,7 @@ add_to_path() {
     local -a path_array
     while read d
     do
-        if [[ ${VIMCONFIG_DIR} != ${d} ]]
+        if [[ ${path} != ${d} ]]
         then
             path_array=( $( echo ${path_array[*]} ) $d )
         fi
@@ -20,7 +20,7 @@ del_from_path() {
     local -a path_array
     while read d
     do
-        if [[ ${VIMCONFIG_DIR} != ${d} ]]
+        if [[ ${path} != ${d} ]]
         then
             path_array=( $( echo ${path_array[*]} ) $d )
         fi

--- a/activate
+++ b/activate
@@ -118,7 +118,7 @@ then
     }
 fi
 
-if [[ ! -f ${VIM_RESET_CONFDIR}/bin/vim ]]
+if [[ ! -e ${VIM_RESET_CONFDIR}/bin/vim ]]
 then
     cat > "${VIM_RESET_CONFDIR}/bin/vim" <<OUTPUT
 #!/usr/bin/env bash
@@ -130,7 +130,14 @@ OUTPUT
     chmod +x "${VIM_RESET_CONFDIR}/bin/vim"
 fi
 
-path_push "${VIM_RESET_CONFDIR}/bin"
+if [[ -f ${VIM_RESET_CONFDIR}/bin/vim ]] && [[ -x ${VIM_RESET_CONFDIR}/bin/vim ]]
+then
+    path_push "${VIM_RESET_CONFDIR}/bin"
+else
+    echo "Something odd has happend, please check your ${VIM_RESET_CONFDIR}"
+    echo "Aborting..."
+    return
+fi
 
 echo "========================"
 echo "VIMRC=${VIM_RESET_VIMRC}"

--- a/activate
+++ b/activate
@@ -308,12 +308,12 @@ vim_reset() {
     echo "VIMRTP=${VIM_RESET_VIMRTP}"
     echo "========================"
 
-    hijack_vim || return $?
+    vim_hijack || return $?
 
     return 0
 }
 
-hijack_vim() {
+vim_hijack() {
     if [[ ! -d ${VIM_RESET_CONFDIR}/bin ]]
     then
         mkdir "${VIM_RESET_CONFDIR}/bin"

--- a/activate
+++ b/activate
@@ -207,16 +207,16 @@ vim_reset() {
 
     if grep -IF 'GENERATED_BY_VIM_RESET' "$( which vim )" &>/dev/null
     then
-        echo "'vim-reset' has been established"
+        echo "'vim-reset' has been established" >&2
 
         if [[ ${force} -eq 1 ]]
         then
-            echo "Re-establishing 'vim-reset'..."
+            echo "Re-establishing 'vim-reset'..." >&2
         fi
 
         if [[ ${force} -eq 1 ]] || [[ ${revert} -eq 1 ]]
         then
-            echo "Reverting changes..."
+            echo "Reverting changes..." >&2
             vim_revert
         fi
 
@@ -227,29 +227,29 @@ vim_reset() {
 
         if [[ ${force} -ne 1 ]]
         then
-            echo "If you want to re-establish the 'vim-reset', then"
-            echo "use '--force' option or set 'VIM_RESET_FORCE' to 1."
-            echo "Aborting..."
+            echo "If you want to re-establish the 'vim-reset', then" >&2
+            echo "use '--force' option or set 'VIM_RESET_FORCE' to 1." >&2
+            echo "Aborting..." >&2
             return 1
         fi
     fi
 
     if [[ ${force} -ne 1 ]] && [[ ${revert} -eq 1 ]]
     then
-        echo "'vim-reset' has not been established yet"
-        echo "Aborting..."
+        echo "'vim-reset' has not been established yet" >&2
+        echo "Aborting..." >&2
         return 1
     fi
 
     if [[ -z ${confdir} ]]
     then
         echo "Either '--confdir' option  or env-variable 'VIM_RESET_CONFDIR' has to be set" >&2
-        echo "Aborting..."
+        echo "Aborting..." >&2
         return 1
     elif [[ ! -d ${confdir} ]]
     then
         echo "The path specified by '--confdir' option  or env-variable 'VIM_RESET_CONFDIR' has to be a valid directory" >&2
-        echo "Aborting..."
+        echo "Aborting..." >&2
         return 1
     else
         echo "Using ${confdir}" >&2
@@ -262,7 +262,7 @@ vim_reset() {
     elif [[ ${force} -ne 1 ]] && [[ -f ${confdir}/bin/vim ]] && \
         [[ -x ${confdir}/bin/vim ]]
     then
-        echo "Use an existing vim-reset facility, ${confdir}/bin"
+        echo "Use an existing vim-reset facility, ${confdir}/bin" >&2
     fi
 
     vim_hijack || return $?
@@ -273,7 +273,8 @@ vim_reset() {
 vim_deploy() {
     local VIM=$( which vim )
     [[ -z ${VIM} ]] && {
-        echo "No VIM installed?"
+        echo "No VIM installed?" >&2
+        echo "Aborting..." >&2
         return 1
     }
 
@@ -288,7 +289,7 @@ vim_deploy() {
     elif [[ ! -f ${vimrc} ]]
     then
         echo "The path specified by '--vimrc' option  or env-variable 'VIM_RESET_VIMRC' has to be a valid file" >&2
-        echo "Aborting..."
+        echo "Aborting..." >&2
         return 1
     fi
 
@@ -298,7 +299,7 @@ vim_deploy() {
     elif [[ ! -f ${gvimrc} ]]
     then
         echo "The path specified by '--gvimrc' option  or env-variable 'VIM_RESET_GVIMRC' has to be a valid file" >&2
-        echo "Aborting..."
+        echo "Aborting..." >&2
         return 1
     fi
 
@@ -342,18 +343,18 @@ vim_deploy() {
     done
     vimrtp=$( IFS=","; echo "${_rtps[*]}" )
 
-    echo "========================"
-    echo "VIMRC=${vimrc}"
-    echo "GVIMRC=${gvimrc}"
-    echo "VIMRTP=${vimrtp}"
-    echo "========================"
+    echo "========================" >&2
+    echo "VIMRC=${vimrc}"           >&2
+    echo "GVIMRC=${gvimrc}"         >&2
+    echo "VIMRTP=${vimrtp}"         >&2
+    echo "========================" >&2
 
     if [[ ! -d ${confdir}/bin ]]
     then
         mkdir "${confdir}/bin"
         [[ $? -ne 0 ]] && {
-            echo "Fail to mkdir ${confdir}/bin"
-            echo "Aborting..."
+            echo "Fail to mkdir ${confdir}/bin" >&2
+            echo "Aborting..." >&2
             return 1
         }
     fi
@@ -390,8 +391,8 @@ vim_hijack() {
     then
         path_push "${confdir}/bin"
     else
-        echo "Something odd has happend, please check ${confdir}/bin/vim"
-        echo "Aborting..."
+        echo "Something odd has happend, please check ${confdir}/bin/vim" >&2
+        echo "Aborting..." >&2
         return 1
     fi
 

--- a/activate
+++ b/activate
@@ -57,7 +57,11 @@ fi
 VIM=$( which vim )
 
 RUNTIMEPATH=${VIM_RESET_CONFDIR},$(get_vim_rtp)
-VIM_RESET_VIMRC=${VIM_RESET_CONFDIR}/_vimrc
+
+if [[ -z ${VIM_RESET_VIMRC} ]]
+then
+    VIM_RESET_VIMRC=${VIM_RESET_CONFDIR}/_vimrc
+fi
 
 if [[ ! -d ${VIM_RESET_CONFDIR}/bin ]]
 then
@@ -89,3 +93,5 @@ then
     echo "WARNING: ${VIM_RESET_VIMRC} doesn't exist, please remember to create it or copy your current ~/.vimrc file" >&2
     echo
 fi
+
+unset VIM_RESET_VIMRC

--- a/activate
+++ b/activate
@@ -51,7 +51,7 @@ A bash script so you can customize your very own VIM configurations.
 
 Usage:
 
-    vim-reset [-h|--help] [-r|--revert] \
+    vim-reset [-h|--help] [-f|--force] [-r|--revert] \
               [--vimrc VIM_RESET_VIMRC] \
               [--gvimrc VIM_RESET_GVIMRC] \
               [--confdir VIM_RESET_CONFDIR] \
@@ -61,6 +61,9 @@ Options:
 
     -h, --help
         Show this help information.
+
+    -f, --force
+        Force re-establishing the 'vim-reset'.
 
     -r, --revert
         Revert the changes made by 'vim-reset'.
@@ -108,6 +111,10 @@ Environment Variables:
         Comma separated directory paths, used as the VIM's 'rtp'
         after the resetting. It is useful for testing plugins.
 
+    * `VIM_RESET_FORCE`
+        Optional.
+        Force re-establishing the 'vim-reset'.
+
     * `VIM_RESET_REVERT`
         Optional.
         Revert the changes made by 'vim-reset'.
@@ -116,6 +123,7 @@ EOF
 }
 
 vim_reset() {
+    declare -i force=${VIM_RESET_FORCE:-0}
     declare -i revert=${VIM_RESET_REVERT:-0}
 
     while [ $# -gt 0 ]
@@ -124,6 +132,9 @@ vim_reset() {
             -h | --help )
                 show_help
                 return 0
+            ;;
+            -f | --force )
+                force=1
             ;;
             -r | --revert )
                 revert=1
@@ -156,18 +167,32 @@ vim_reset() {
     then
         echo "'vim-reset' has been established"
 
-        if [[ ${revert} -eq 1 ]]
+        if [[ ${force} -eq 1 ]]
+        then
+            echo "Re-establishing 'vim-reset'..."
+        fi
+
+        if [[ ${force} -eq 1 ]] || [[ ${revert} -eq 1 ]]
         then
             echo "Reverting changes..."
             vim_revert
+        fi
+
+        if [[ ${force} -ne 1 ]] && [[ ${revert} -eq 1 ]]
+        then
             return 0
         fi
 
-        echo "Aborting..."
-        return 1
+        if [[ ${force} -ne 1 ]]
+        then
+            echo "If you want to re-establish the 'vim-reset', then"
+            echo "use '--force' option or set 'VIM_RESET_FORCE' to 1."
+            echo "Aborting..."
+            return 1
+        fi
     fi
 
-    if [[ ${revert} -eq 1 ]]
+    if [[ ${force} -ne 1 ]] && [[ ${revert} -eq 1 ]]
     then
         echo "'vim-reset' has not been established yet"
         echo "Aborting..."
@@ -274,7 +299,8 @@ hijack_vim() {
         }
     fi
 
-    if [[ ! -e ${VIM_RESET_CONFDIR}/bin/vim ]]
+    if [[ ! -e ${VIM_RESET_CONFDIR}/bin/vim ]] || \
+        [[ -f ${VIM_RESET_CONFDIR}/bin/vim ]] && [[ ${force} -eq 1 ]]
     then
         cat > "${VIM_RESET_CONFDIR}/bin/vim" <<OUTPUT
 #!/usr/bin/env bash
@@ -286,7 +312,8 @@ OUTPUT
         chmod +x "${VIM_RESET_CONFDIR}/bin/vim"
     fi
 
-    if [[ ! -e ${VIM_RESET_CONFDIR}/bin/gvim ]]
+    if [[ ! -e ${VIM_RESET_CONFDIR}/bin/gvim ]] || \
+        [[ -f ${VIM_RESET_CONFDIR}/bin/gvim ]] && [[ ${force} -eq 1 ]]
     then
         cat > "${VIM_RESET_CONFDIR}/bin/gvim" <<OUTPUT
 #!/usr/bin/env bash

--- a/activate
+++ b/activate
@@ -174,7 +174,7 @@ vim_reset() {
         shift
     done
 
-    if check_vim_reset
+    if grep -IF 'GENERATED_BY_VIM_RESET' "$( which vim )" &>/dev/null
     then
         echo "'vim-reset' has been established"
 
@@ -375,11 +375,6 @@ get_vim_rtp() {
             -c "redir! > /dev/stdout" -c 'set runtimepath' -c 'q' | \
             tail -n1 | cut -d= -f2-
     fi
-}
-
-# check if vim-reset is already working now
-check_vim_reset() {
-    grep -IF 'GENERATED_BY_VIM_RESET' "$( which vim )" &>/dev/null
 }
 
 alias vim-reset=vim_reset

--- a/activate
+++ b/activate
@@ -218,16 +218,6 @@ vim_reset() {
         return 1
     fi
 
-    VIM=$( which vim )
-    [[ -z ${VIM} ]] && {
-        echo "No VIM installed?"
-        return 1
-    }
-    GVIM=$( which gvim )
-    [[ -z ${GVIM} ]] && {
-        GVIM=${VIM}
-    }
-
     if [[ -z ${VIM_RESET_CONFDIR} ]]
     then
         echo "Either '--confdir' option  or env-variable 'VIM_RESET_CONFDIR' has to be set" >&2
@@ -241,6 +231,23 @@ vim_reset() {
     else
         echo "Using ${VIM_RESET_CONFDIR}" >&2
     fi
+
+    vim_hijack || return $?
+
+    return 0
+}
+
+vim_hijack() {
+    VIM=$( which vim )
+    [[ -z ${VIM} ]] && {
+        echo "No VIM installed?"
+        return 1
+    }
+
+    GVIM=$( which gvim )
+    [[ -z ${GVIM} ]] && {
+        GVIM=${VIM}
+    }
 
     if [[ -z ${VIM_RESET_VIMRC} ]]
     then
@@ -308,12 +315,6 @@ vim_reset() {
     echo "VIMRTP=${VIM_RESET_VIMRTP}"
     echo "========================"
 
-    vim_hijack || return $?
-
-    return 0
-}
-
-vim_hijack() {
     if [[ ! -d ${VIM_RESET_CONFDIR}/bin ]]
     then
         mkdir "${VIM_RESET_CONFDIR}/bin"

--- a/activate
+++ b/activate
@@ -38,6 +38,12 @@ then
     return
 fi
 
+VIM=$( which vim )
+[[ -z ${VIM} ]] && {
+    echo "No VIM installed?"
+    return
+}
+
 if [[ -z ${VIM_RESET_CONFDIR} ]]
 then
     echo "Env-variable 'VIM_RESET_CONFDIR' has to be set" >&2
@@ -52,8 +58,6 @@ then
     echo "Creating ${VIM_RESET_CONFDIR}" >&2
     mkdir -p "${VIM_RESET_CONFDIR}"
 fi
-
-VIM=$( which vim )
 
 if [[ -z ${VIM_RESET_VIMRC} ]]
 then

--- a/activate
+++ b/activate
@@ -44,6 +44,89 @@ normalize() {
   pwd
 }
 
+vim_reset() {
+    if check_vim_reset
+    then
+        return 1
+    fi
+
+    VIM=$( which vim )
+    [[ -z ${VIM} ]] && {
+        echo "No VIM installed?"
+        return 1
+    }
+    GVIM=$( which gvim )
+    [[ -z ${GVIM} ]] && {
+        GVIM=${VIM}
+    }
+
+    if [[ -z ${VIM_RESET_CONFDIR} ]]
+    then
+        echo "Env-variable 'VIM_RESET_CONFDIR' has to be set" >&2
+        echo "Aborting..."
+        return 1
+    else
+        echo "Using ${VIM_RESET_CONFDIR}" >&2
+    fi
+
+    if [[ -z ${VIM_RESET_VIMRC} ]]
+    then
+        VIM_RESET_VIMRC=${VIM_RESET_CONFDIR}/_vimrc
+    fi
+
+    if [[ -z ${VIM_RESET_GVIMRC} ]]
+    then
+        VIM_RESET_GVIMRC=${VIM_RESET_CONFDIR}/_gvimrc
+    fi
+
+    if [[ -n ${VIM_RESET_VIMRTP} ]]
+    then
+        VIM_RESET_VIMRTP=${VIM_RESET_CONFDIR},${VIM_RESET_VIMRTP}
+    else
+        VIM_RESET_VIMRTP=${VIM_RESET_CONFDIR}
+    fi
+
+    VIM_RESET_VIMRTP=${VIM_RESET_VIMRTP},"~/.vim"
+
+    declare -a rtps
+    IFS=',' read -ra rtps < <(unset IFS;echo ${VIM_RESET_VIMRTP})
+
+    declare -a _rtps
+    IFS=',' read -ra _rtps < <(get_vim_rtp)
+
+    for rtp_i in ${!rtps[*]}
+    do
+        # Preserve the exact order of the rtps
+        rtp=${rtps[$((${#rtps[@]} - ${rtp_i} - 1))]}
+
+        # Skip non-directory path
+        [[ -d ${rtp} ]] || continue
+
+        # Remove duplicate paths
+        for _rtp_i in ${!_rtps[*]}
+        do
+            _rtp=${_rtps[${_rtp_i}]}
+            {
+                [[ ${rtp%/} == ${_rtp%/} ]] || \
+                    [[ ${rtp%/}/after == ${_rtp%/} ]]
+            } && {
+                unset _rtps[${_rtp_i}]
+            }
+        done
+        [[ ${rtp} == "~/.vim" ]] && continue
+        _rtps=( "${rtp}" "${_rtps[@]}" "${rtp}"/after )
+    done
+    VIM_RESET_VIMRTP=$( IFS=","; echo "${_rtps[*]}" )
+
+    echo "========================"
+    echo "VIMRC=${VIM_RESET_VIMRC}"
+    echo "GVIMRC=${VIM_RESET_GVIMRC}"
+    echo "VIMRTP=${VIM_RESET_VIMRTP}"
+    echo "========================"
+
+    hijack_vim || return 1
+}
+
 hijack_vim() {
     if [[ ! -d ${VIM_RESET_CONFDIR} ]]
     then
@@ -118,84 +201,4 @@ check_vim_reset() {
     grep -IF 'GENERATED_BY_VIM_RESET' "$( which vim )" &>/dev/null
 }
 
-if check_vim_reset
-then
-    return 1
-fi
-
-VIM=$( which vim )
-[[ -z ${VIM} ]] && {
-    echo "No VIM installed?"
-    return 1
-}
-
-GVIM=$( which gvim )
-[[ -z ${GVIM} ]] && {
-    GVIM=${VIM}
-}
-
-if [[ -z ${VIM_RESET_CONFDIR} ]]
-then
-    echo "Env-variable 'VIM_RESET_CONFDIR' has to be set" >&2
-    echo "Aborting..."
-    return 1
-else
-    echo "Using ${VIM_RESET_CONFDIR}" >&2
-fi
-
-if [[ -z ${VIM_RESET_VIMRC} ]]
-then
-    VIM_RESET_VIMRC=${VIM_RESET_CONFDIR}/_vimrc
-fi
-
-if [[ -z ${VIM_RESET_GVIMRC} ]]
-then
-    VIM_RESET_GVIMRC=${VIM_RESET_CONFDIR}/_gvimrc
-fi
-
-if [[ -n ${VIM_RESET_VIMRTP} ]]
-then
-    VIM_RESET_VIMRTP=${VIM_RESET_CONFDIR},${VIM_RESET_VIMRTP}
-else
-    VIM_RESET_VIMRTP=${VIM_RESET_CONFDIR}
-fi
-
-VIM_RESET_VIMRTP=${VIM_RESET_VIMRTP},"~/.vim"
-
-declare -a rtps
-IFS=',' read -ra rtps < <(unset IFS;echo ${VIM_RESET_VIMRTP})
-
-declare -a _rtps
-IFS=',' read -ra _rtps < <(get_vim_rtp)
-
-for rtp_i in ${!rtps[*]}
-do
-    # Preserve the exact order of the rtps
-    rtp=${rtps[$((${#rtps[@]} - ${rtp_i} - 1))]}
-
-    # Skip non-directory path
-    [[ -d ${rtp} ]] || continue
-
-    # Remove duplicate paths
-    for _rtp_i in ${!_rtps[*]}
-    do
-        _rtp=${_rtps[${_rtp_i}]}
-        {
-            [[ ${rtp%/} == ${_rtp%/} ]] || \
-                [[ ${rtp%/}/after == ${_rtp%/} ]]
-        } && {
-            unset _rtps[${_rtp_i}]
-        }
-    done
-    [[ ${rtp} == "~/.vim" ]] && continue
-    _rtps=( "${rtp}" "${_rtps[@]}" "${rtp}"/after )
-done
-VIM_RESET_VIMRTP=$( IFS=","; echo "${_rtps[*]}" )
-
-echo "========================"
-echo "VIMRC=${VIM_RESET_VIMRC}"
-echo "GVIMRC=${VIM_RESET_GVIMRC}"
-echo "VIMRTP=${VIM_RESET_VIMRTP}"
-echo "========================"
-
-hijack_vim || return 1
+alias vim-reset=vim_reset

--- a/activate
+++ b/activate
@@ -186,6 +186,11 @@ vim_reset() {
         shift
     done
 
+    if [[ -z ${confdir} ]]
+    then
+        force=0
+    fi
+
     if grep -IF 'GENERATED_BY_VIM_RESET' "$( which vim )" &>/dev/null
     then
         echo "'vim-reset' has been established"

--- a/activate
+++ b/activate
@@ -30,9 +30,13 @@ get_vim_rtp() {
 
 # check if vim-reset is already working now
 check_vim_reset() {
-    path_push "${VIM_RESET_CONFDIR}/bin"
     grep -IF 'GENERATED_BY_VIM_RESET' "$( which vim )" &>/dev/null
 }
+
+if check_vim_reset
+then
+    return
+fi
 
 if [[ -z ${VIM_RESET_CONFDIR} ]]
 then
@@ -41,11 +45,6 @@ then
     return
 else
     echo "Using ${VIM_RESET_CONFDIR}" >&2
-fi
-
-if check_vim_reset
-then
-    return
 fi
 
 if [[ ! -d ${VIM_RESET_CONFDIR} ]]

--- a/activate
+++ b/activate
@@ -225,6 +225,11 @@ vim_reset() {
         echo "Either '--confdir' option  or env-variable 'VIM_RESET_CONFDIR' has to be set" >&2
         echo "Aborting..."
         return 1
+    elif [[ ! -d ${VIM_RESET_CONFDIR} ]]
+    then
+        echo "The path specified by '--confdir' option  or env-variable 'VIM_RESET_CONFDIR' has to be a valid directory" >&2
+        echo "Aborting..."
+        return 1
     else
         echo "Using ${VIM_RESET_CONFDIR}" >&2
     fi
@@ -289,17 +294,6 @@ vim_reset() {
 }
 
 hijack_vim() {
-    if [[ ! -d ${VIM_RESET_CONFDIR} ]]
-    then
-        echo "Creating ${VIM_RESET_CONFDIR}" >&2
-        mkdir -p "${VIM_RESET_CONFDIR}"
-        [[ $? -ne 0 ]] && {
-            echo "Fail to mkdir ${VIM_RESET_CONFDIR}"
-            echo "Aborting..."
-            return 1
-        }
-    fi
-
     if [[ ! -d ${VIM_RESET_CONFDIR}/bin ]]
     then
         mkdir "${VIM_RESET_CONFDIR}/bin"

--- a/activate
+++ b/activate
@@ -51,7 +51,7 @@ A bash script so you can customize your very own VIM configurations.
 
 Usage:
 
-    vim-reset [-h|--help] \
+    vim-reset [-h|--help] [-r|--revert] \
               [--vimrc VIM_RESET_VIMRC] \
               [--gvimrc VIM_RESET_GVIMRC] \
               [--confdir VIM_RESET_CONFDIR] \
@@ -61,6 +61,9 @@ Options:
 
     -h, --help
         Show this help information.
+
+    -r, --revert
+        Revert the changes made by 'vim-reset'.
 
     --vimrc VIM_RESET_VIMRC
         VIM configuration file to be used.
@@ -105,16 +108,25 @@ Environment Variables:
         Comma separated directory paths, used as the VIM's 'rtp'
         after the resetting. It is useful for testing plugins.
 
+    * `VIM_RESET_REVERT`
+        Optional.
+        Revert the changes made by 'vim-reset'.
+
 EOF
 }
 
 vim_reset() {
+    declare -i revert=${VIM_RESET_REVERT:-0}
+
     while [ $# -gt 0 ]
     do
         case $1 in
             -h | --help )
                 show_help
                 return 0
+            ;;
+            -r | --revert )
+                revert=1
             ;;
             --vimrc )
                 VIM_RESET_VIMRC=$2
@@ -142,6 +154,23 @@ vim_reset() {
 
     if check_vim_reset
     then
+        echo "'vim-reset' has been established"
+
+        if [[ ${revert} -eq 1 ]]
+        then
+            echo "Reverting changes..."
+            vim_revert
+            return 0
+        fi
+
+        echo "Aborting..."
+        return 1
+    fi
+
+    if [[ ${revert} -eq 1 ]]
+    then
+        echo "'vim-reset' has not been established yet"
+        echo "Aborting..."
         return 1
     fi
 
@@ -284,6 +313,13 @@ OUTPUT
     unset VIM_RESET_VIMRC
     unset VIM_RESET_GVIMRC
     unset VIM_RESET_VIMRTP
+}
+
+vim_revert() {
+    while grep -IF 'GENERATED_BY_VIM_RESET' "$( which vim )" &>/dev/null
+    do
+        path_pop "$( dirname $( which vim ) )"
+    done
 }
 
 get_vim_rtp() {

--- a/activate
+++ b/activate
@@ -6,7 +6,7 @@ add_to_path() {
     local -a path_array
     while read d
     do
-        if [[ "${VIMCONFIG_DIR}" != "${d}" ]]
+        if [[ ${VIMCONFIG_DIR} != ${d} ]]
         then
             path_array=( $( echo ${path_array[*]} ) $d )
         fi
@@ -20,7 +20,7 @@ del_from_path() {
     local -a path_array
     while read d
     do
-        if [[ "${VIMCONFIG_DIR}" != "${d}" ]]
+        if [[ ${VIMCONFIG_DIR} != ${d} ]]
         then
             path_array=( $( echo ${path_array[*]} ) $d )
         fi
@@ -34,7 +34,7 @@ check_vim_reset() {
     grep -IF 'GENERATED_BY_VIM_RESET' $( which vim ) &>/dev/null
 }
 
-if [[ -z "${VIMCONFIG_DIR}" ]]
+if [[ -z ${VIMCONFIG_DIR} ]]
 then
     # this is a common one-liner copied from
     # http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
@@ -50,7 +50,7 @@ then
     return
 fi
 
-if [[ ! -d "${VIMCONFIG_DIR}" ]]
+if [[ ! -d ${VIMCONFIG_DIR} ]]
 then
     echo "Creating ${VIMCONFIG_DIR}" >&2
     mkdir -p "${VIMCONFIG_DIR}"
@@ -68,12 +68,12 @@ OLD_RUNTIMEPATH=$( tail -n1 $TEMP | awk -F= '{print $2}' | cut -d, -f2- )
 RUNTIMEPATH=${VIMCONFIG_DIR},${OLD_RUNTIMEPATH}
 VIMRC=${VIMCONFIG_DIR}/_vimrc
 
-if [[ ! -d "${VIMCONFIG_DIR}/bin" ]]
+if [[ ! -d ${VIMCONFIG_DIR}/bin ]]
 then
     mkdir ${VIMCONFIG_DIR}/bin
 fi
 
-if [[ ! -f "${VIMCONFIG_DIR}/bin/vim" ]]
+if [[ ! -f ${VIMCONFIG_DIR}/bin/vim ]]
 then
     cat > ${VIMCONFIG_DIR}/bin/vim <<OUTPUT
 #!/usr/bin/env bash
@@ -92,7 +92,7 @@ echo "VIMRC=${VIMRC}"
 echo "VIMRUNTIME=${RUNTIMEPATH}"
 echo "========================"
 
-if [[ ! -f "${VIMRC}" ]]
+if [[ ! -f ${VIMRC} ]]
 then
     echo
     echo "WARNING: ${VIMRC} doesn't exist, please remember to create it or copy your current ~/.vimrc file" >&2

--- a/activate
+++ b/activate
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 
+# escape $' \n \t' characters in a string
+escape() {
+    res=$1
+    res=${res// /\\ }
+    res=${res//$'\t'/\\$'\t'}
+    res=${res//$'\n'/\\$'\n'}
+    echo "${res}"
+
+    return 0
+}
+
 # pop $1 from PATH environment variable
 path_pop() {
     local path=$1
@@ -8,7 +19,7 @@ path_pop() {
     IFS=':' read -ra path_array <<< "$PATH"
     for path_index in ${!path_array[*]}
     do
-        [[ ${path%/} == ${path_array[${path_index}]%/} ]] && {
+        eval [[ $( escape "${path%/}" ) == $( escape "${path_array[${path_index}]%/}" ) ]] && {
             unset path_array[${path_index}]
         }
     done
@@ -313,15 +324,15 @@ vim_deploy() {
         rtp=${rtps[$((${#rtps[@]} - ${rtp_i} - 1))]}
 
         # Skip non-directory path
-        [[ -d ${rtp} ]] || continue
+        eval [[ -d $( escape "${rtp}" ) ]] || continue
 
         # Remove duplicate paths
         for _rtp_i in ${!_rtps[*]}
         do
             _rtp=${_rtps[${_rtp_i}]}
             {
-                [[ ${rtp%/} == ${_rtp%/} ]] || \
-                    [[ ${rtp%/}/after == ${_rtp%/} ]]
+                eval [[ $( escape "${rtp%/}" ) == $( escape "${_rtp%/}" ) ]] || \
+                    eval [[ $( escape "${rtp%/}/after" ) == $( escape "${_rtp%/}" ) ]]
             } && {
                 unset _rtps[${_rtp_i}]
             }

--- a/activate
+++ b/activate
@@ -61,7 +61,7 @@ then
     VIM_RESET_VIMRC=${VIM_RESET_CONFDIR}/_vimrc
 fi
 
-VIM_RESET_VIMRTP=${VIM_RESET_CONFDIR},$(get_vim_rtp)
+VIM_RESET_VIMRTP=${VIM_RESET_CONFDIR},$(get_vim_rtp),${VIM_RESET_CONFDIR}/after
 
 if [[ ! -d ${VIM_RESET_CONFDIR}/bin ]]
 then

--- a/activate
+++ b/activate
@@ -1,21 +1,7 @@
 #!/usr/bin/env bash
 
-# add $1 as the first directory of PATH environment variable
-add_to_path() {
-    local path=$1
-    local -a path_array
-    while read d
-    do
-        if [[ ${path%/} != ${d%/} ]]
-        then
-            path_array=( $( echo ${path_array[*]} ) $d )
-        fi
-    done<<<$( echo $PATH |tr ':' ' ' )
-    export PATH=${path}:$( IFS=":"; echo "${path_array[*]}" )
-}
-
-# delete $1 from PATH environment variable
-del_from_path() {
+# pop $1 from PATH environment variable
+path_pop() {
     local path=$1
     local -a path_array
     while read d
@@ -28,9 +14,23 @@ del_from_path() {
     export PATH=$( IFS=":"; echo "${path_array[*]}" )
 }
 
+# push $1 as the first directory of PATH environment variable
+path_push() {
+    local path=$1
+    local -a path_array
+    while read d
+    do
+        if [[ ${path%/} != ${d%/} ]]
+        then
+            path_array=( $( echo ${path_array[*]} ) $d )
+        fi
+    done<<<$( echo $PATH |tr ':' ' ' )
+    export PATH=${path}:$( IFS=":"; echo "${path_array[*]}" )
+}
+
 # check if vim-reset is already working now
 check_vim_reset() {
-    add_to_path "${VIMCONFIG_DIR}/bin"
+    path_push "${VIMCONFIG_DIR}/bin"
     grep -IF 'GENERATED_BY_VIM_RESET' "$( which vim )" &>/dev/null
 }
 
@@ -83,7 +83,7 @@ OUTPUT
     chmod +x "${VIMCONFIG_DIR}/bin/vim"
 fi
 
-add_to_path "${VIMCONFIG_DIR}/bin"
+path_push "${VIMCONFIG_DIR}/bin"
 
 echo "========================"
 echo "VIMRC=${VIMRC}"

--- a/activate
+++ b/activate
@@ -53,6 +53,7 @@ Usage:
 
     vim-reset [-h|--help] \
               [--vimrc VIM_RESET_VIMRC] \
+              [--gvimrc VIM_RESET_GVIMRC] \
               [--confdir VIM_RESET_CONFDIR] \
               [--add-rtp ADDITIONAL_RTP_PATH] ..
 
@@ -64,6 +65,11 @@ Options:
     --vimrc VIM_RESET_VIMRC
         VIM configuration file to be used.
         If both this option and env-viriable 'VIM_RESET_VIMRC' are
+        set, the value of this option will be used.
+
+    --gvimrc VIM_RESET_GVIMRC
+        GVIM configuration file to be used.
+        If both this option and env-viriable 'VIM_RESET_GVIMRC' are
         set, the value of this option will be used.
 
     --confdir VIM_RESET_CONFDIR
@@ -112,6 +118,10 @@ vim_reset() {
             ;;
             --vimrc )
                 VIM_RESET_VIMRC=$2
+                shift
+            ;;
+            --gvimrc )
+                VIM_RESET_GVIMRC=$2
                 shift
             ;;
             --confdir )

--- a/activate
+++ b/activate
@@ -189,6 +189,9 @@ vim_reset() {
     if [[ -z ${confdir} ]]
     then
         force=0
+    elif [[ ${hard} -eq 1 ]] || [[ -n ${vimrc} ]] || [[ -n ${gvimrc} ]] || [[ -n ${vimrtp} ]]
+    then
+        force=1
     fi
 
     if grep -IF 'GENERATED_BY_VIM_RESET' "$( which vim )" &>/dev/null

--- a/activate
+++ b/activate
@@ -163,7 +163,7 @@ fi
 VIM_RESET_VIMRTP=${VIM_RESET_VIMRTP},"~/.vim"
 
 declare -a rtps
-IFS=',' read -ra rtps < <(echo ${VIM_RESET_VIMRTP})
+IFS=',' read -ra rtps < <(unset IFS;echo ${VIM_RESET_VIMRTP})
 
 declare -a _rtps
 IFS=',' read -ra _rtps < <(get_vim_rtp)

--- a/activate
+++ b/activate
@@ -19,7 +19,29 @@ path_pop() {
 path_push() {
     local path=$1
     path_pop "${path}"
-    export PATH=${path}:$PATH
+    export PATH=$(normalize "${path}"):$PATH
+}
+
+#
+# Function: normalize
+#
+# Normalize a given path.
+
+# Do not follow symlink. If the given path is a
+# file, normalize parent directory.
+#
+# Params:
+#
+#  $1  path to normalize
+#
+normalize() {
+  local path=$1
+  cd "${path}" 2> /dev/null
+  if [ $? -eq 1 ]; then
+    path=$(dirname "${path}")
+    cd "${path}"
+  fi
+  pwd
 }
 
 get_vim_rtp() {

--- a/activate
+++ b/activate
@@ -313,7 +313,7 @@ vim_deploy() {
     vimrtp=${vimrtp},"~/.vim"
 
     declare -a rtps
-    IFS=',' read -ra rtps < <(unset IFS;echo ${vimrtp})
+    IFS=',' read -ra rtps <<< "${vimrtp}"
 
     declare -a _rtps
     IFS=',' read -ra _rtps < <(get_vim_rtp)

--- a/activate
+++ b/activate
@@ -57,7 +57,7 @@ fi
 VIM=$( which vim )
 
 RUNTIMEPATH=${VIM_RESET_CONFDIR},$(get_vim_rtp)
-VIMRC=${VIM_RESET_CONFDIR}/_vimrc
+VIM_RESET_VIMRC=${VIM_RESET_CONFDIR}/_vimrc
 
 if [[ ! -d ${VIM_RESET_CONFDIR}/bin ]]
 then
@@ -71,7 +71,7 @@ then
 # GENERATED_BY_VIM_RESET
 # don't delete the line above
 
-${VIM} --cmd 'set runtimepath=${RUNTIMEPATH}' -u '${VIMRC}' \$@
+${VIM} --cmd 'set runtimepath=${RUNTIMEPATH}' -u '${VIM_RESET_VIMRC}' \$@
 OUTPUT
     chmod +x "${VIM_RESET_CONFDIR}/bin/vim"
 fi
@@ -79,13 +79,13 @@ fi
 path_push "${VIM_RESET_CONFDIR}/bin"
 
 echo "========================"
-echo "VIMRC=${VIMRC}"
+echo "VIMRC=${VIM_RESET_VIMRC}"
 echo "VIMRUNTIME=${RUNTIMEPATH}"
 echo "========================"
 
-if [[ ! -f ${VIMRC} ]]
+if [[ ! -f ${VIM_RESET_VIMRC} ]]
 then
     echo
-    echo "WARNING: ${VIMRC} doesn't exist, please remember to create it or copy your current ~/.vimrc file" >&2
+    echo "WARNING: ${VIM_RESET_VIMRC} doesn't exist, please remember to create it or copy your current ~/.vimrc file" >&2
     echo
 fi

--- a/activate
+++ b/activate
@@ -61,7 +61,27 @@ then
     VIM_RESET_VIMRC=${VIM_RESET_CONFDIR}/_vimrc
 fi
 
-VIM_RESET_VIMRTP=${VIM_RESET_CONFDIR},$(get_vim_rtp),${VIM_RESET_CONFDIR}/after
+if [[ -n ${VIM_RESET_VIMRTP} ]]
+then
+    VIM_RESET_VIMRTP=${VIM_RESET_CONFDIR},${VIM_RESET_VIMRTP}
+else
+    VIM_RESET_VIMRTP=${VIM_RESET_CONFDIR}
+fi
+
+declare -a rtps
+IFS=',' read -ra rtps < <(echo ${VIM_RESET_VIMRTP})
+
+VIM_RESET_VIMRTP=$(get_vim_rtp)
+for rtp_i in ${!rtps[*]}
+do
+    # Preserve the exact order of the rtps
+    rtp=${rtps[$((${#rtps[@]} - ${rtp_i} - 1))]}
+
+    # Skip non-directory path
+    [[ -d ${rtp} ]] || continue
+
+    VIM_RESET_VIMRTP=${rtp},${VIM_RESET_VIMRTP},${rtp}/after
+done
 
 if [[ ! -d ${VIM_RESET_CONFDIR}/bin ]]
 then
@@ -95,3 +115,4 @@ then
 fi
 
 unset VIM_RESET_VIMRC
+unset VIM_RESET_VIMRTP

--- a/activate
+++ b/activate
@@ -237,11 +237,21 @@ vim_reset() {
     if [[ -z ${VIM_RESET_VIMRC} ]]
     then
         VIM_RESET_VIMRC=${VIM_RESET_CONFDIR}/_vimrc
+    elif [[ ! -f ${VIM_RESET_VIMRC} ]]
+    then
+        echo "The path specified by '--vimrc' option  or env-variable 'VIM_RESET_VIMRC' has to be a valid file" >&2
+        echo "Aborting..."
+        return 1
     fi
 
     if [[ -z ${VIM_RESET_GVIMRC} ]]
     then
         VIM_RESET_GVIMRC=${VIM_RESET_CONFDIR}/_gvimrc
+    elif [[ ! -f ${VIM_RESET_VIMRC} ]]
+    then
+        echo "The path specified by '--gvimrc' option  or env-variable 'VIM_RESET_GVIMRC' has to be a valid file" >&2
+        echo "Aborting..."
+        return 1
     fi
 
     if [[ -n ${VIM_RESET_VIMRTP} ]]

--- a/activate
+++ b/activate
@@ -11,7 +11,7 @@ add_to_path() {
             path_array=( $( echo ${path_array[*]} ) $d )
         fi
     done<<<$( echo $PATH |tr ':' ' ' )
-    export PATH="${mypath}:$( IFS=":"; echo "${path_array[*]}" )"
+    export PATH=${mypath}:$( IFS=":"; echo "${path_array[*]}" )
 }
 
 # delete $1 from PATH environment variable
@@ -25,7 +25,7 @@ del_from_path() {
             path_array=( $( echo ${path_array[*]} ) $d )
         fi
     done<<<$( echo $PATH |tr ':' ' ' )
-    export PATH="$( IFS=":"; echo "${path_array[*]}" )"
+    export PATH=$( IFS=":"; echo "${path_array[*]}" )
 }
 
 # check if vim-reset is already working now
@@ -38,8 +38,8 @@ if [[ -z "${VIMCONFIG_DIR}" ]]
 then
     # this is a common one-liner copied from
     # http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
-    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-    VIMCONFIG_DIR="${SCRIPT_DIR}/vimconfig"
+    SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+    VIMCONFIG_DIR=${SCRIPT_DIR}/vimconfig
     echo "You didn't specify VIMCONFIG_DIR environment, default using ${VIMCONFIG_DIR}" >&2
 else
     echo "Using ${VIMCONFIG_DIR}" >&2
@@ -65,8 +65,8 @@ ${VIM} -c "redir! > $TEMP" -c 'set runtimepath' -c 'q'
 
 OLD_RUNTIMEPATH=$( tail -n1 $TEMP | awk -F= '{print $2}' | cut -d, -f2- )
 
-RUNTIMEPATH="${VIMCONFIG_DIR},${OLD_RUNTIMEPATH}"
-VIMRC="${VIMCONFIG_DIR}/_vimrc"
+RUNTIMEPATH=${VIMCONFIG_DIR},${OLD_RUNTIMEPATH}
+VIMRC=${VIMCONFIG_DIR}/_vimrc
 
 if [[ ! -d "${VIMCONFIG_DIR}/bin" ]]
 then

--- a/activate
+++ b/activate
@@ -25,7 +25,7 @@ path_push() {
 get_vim_rtp() {
     ${VIM} 2>/dev/null \
         -c "redir! > /dev/stdout" -c 'set runtimepath' -c 'q' | \
-        tail -n1 | awk -F= '{print $2}' | cut -d, -f2-
+        tail -n1 | cut -d= -f2- | cut -d, -f2-
 }
 
 # check if vim-reset is already working now

--- a/activate
+++ b/activate
@@ -141,6 +141,10 @@ vim_reset() {
     declare -i hard=${VIM_RESET_HARD:-0}
     declare -i force=${VIM_RESET_FORCE:-0}
     declare -i revert=${VIM_RESET_REVERT:-0}
+    local confdir=${VIM_RESET_CONFDIR}
+    local vimrc=${VIM_RESET_VIMRC}
+    local gvimrc=${VIM_RESET_GVIMRC}
+    local vimrtp=${VIM_RESET_VIMRTP}
 
     while [ $# -gt 0 ]
     do
@@ -159,22 +163,22 @@ vim_reset() {
                 revert=1
             ;;
             --vimrc )
-                VIM_RESET_VIMRC=$2
+                vimrc=$2
                 shift
             ;;
             --gvimrc )
-                VIM_RESET_GVIMRC=$2
+                gvimrc=$2
                 shift
             ;;
             --confdir )
-                VIM_RESET_CONFDIR=${2%/}
+                confdir=${2%/}
                 shift
             ;;
             --add-rtp )
-                [[ -z ${VIM_RESET_VIMRTP} ]] && {
-                    VIM_RESET_VIMRTP=${2%/}
+                [[ -z ${vimrtp} ]] && {
+                    vimrtp=${2%/}
                 } || {
-                    VIM_RESET_VIMRTP=${VIM_RESET_VIMRTP},${2%/}
+                    vimrtp=${vimrtp},${2%/}
                 }
                 shift
             ;;
@@ -218,26 +222,28 @@ vim_reset() {
         return 1
     fi
 
-    if [[ -z ${VIM_RESET_CONFDIR} ]]
+    if [[ -z ${confdir} ]]
     then
         echo "Either '--confdir' option  or env-variable 'VIM_RESET_CONFDIR' has to be set" >&2
         echo "Aborting..."
         return 1
-    elif [[ ! -d ${VIM_RESET_CONFDIR} ]]
+    elif [[ ! -d ${confdir} ]]
     then
         echo "The path specified by '--confdir' option  or env-variable 'VIM_RESET_CONFDIR' has to be a valid directory" >&2
         echo "Aborting..."
         return 1
     else
-        echo "Using ${VIM_RESET_CONFDIR}" >&2
+        echo "Using ${confdir}" >&2
     fi
 
-    if [[ ${force} -eq 1 ]] && [[ -f ${VIM_RESET_CONFDIR}/bin/vim ]] || [[ ! -e ${VIM_RESET_CONFDIR}/bin/vim ]]
+    if [[ ${force} -eq 1 ]] && [[ -f ${confdir}/bin/vim ]] || \
+        [[ ! -e ${confdir}/bin/vim ]]
     then
         vim_deploy || return $?
-    elif [[ ${force} -ne 1 ]] && [[ -f ${VIM_RESET_CONFDIR}/bin/vim ]] && [[ -x ${VIM_RESET_CONFDIR}/bin/vim ]]
+    elif [[ ${force} -ne 1 ]] && [[ -f ${confdir}/bin/vim ]] && \
+        [[ -x ${confdir}/bin/vim ]]
     then
-        echo "Use an existing vim-reset facility, ${VIM_RESET_CONFDIR}/bin"
+        echo "Use an existing vim-reset facility, ${confdir}/bin"
     fi
 
     vim_hijack || return $?
@@ -246,48 +252,48 @@ vim_reset() {
 }
 
 vim_deploy() {
-    VIM=$( which vim )
+    local VIM=$( which vim )
     [[ -z ${VIM} ]] && {
         echo "No VIM installed?"
         return 1
     }
 
-    GVIM=$( which gvim )
+    local GVIM=$( which gvim )
     [[ -z ${GVIM} ]] && {
         GVIM=${VIM}
     }
 
-    if [[ -z ${VIM_RESET_VIMRC} ]]
+    if [[ -z ${vimrc} ]]
     then
-        VIM_RESET_VIMRC=${VIM_RESET_CONFDIR}/_vimrc
-    elif [[ ! -f ${VIM_RESET_VIMRC} ]]
+        vimrc=${confdir}/_vimrc
+    elif [[ ! -f ${vimrc} ]]
     then
         echo "The path specified by '--vimrc' option  or env-variable 'VIM_RESET_VIMRC' has to be a valid file" >&2
         echo "Aborting..."
         return 1
     fi
 
-    if [[ -z ${VIM_RESET_GVIMRC} ]]
+    if [[ -z ${gvimrc} ]]
     then
-        VIM_RESET_GVIMRC=${VIM_RESET_CONFDIR}/_gvimrc
-    elif [[ ! -f ${VIM_RESET_VIMRC} ]]
+        gvimrc=${confdir}/_gvimrc
+    elif [[ ! -f ${gvimrc} ]]
     then
         echo "The path specified by '--gvimrc' option  or env-variable 'VIM_RESET_GVIMRC' has to be a valid file" >&2
         echo "Aborting..."
         return 1
     fi
 
-    if [[ -n ${VIM_RESET_VIMRTP} ]]
+    if [[ -n ${vimrtp} ]]
     then
-        VIM_RESET_VIMRTP=${VIM_RESET_CONFDIR},${VIM_RESET_VIMRTP}
+        vimrtp=${confdir},${vimrtp}
     else
-        VIM_RESET_VIMRTP=${VIM_RESET_CONFDIR}
+        vimrtp=${confdir}
     fi
 
-    VIM_RESET_VIMRTP=${VIM_RESET_VIMRTP},"~/.vim"
+    vimrtp=${vimrtp},"~/.vim"
 
     declare -a rtps
-    IFS=',' read -ra rtps < <(unset IFS;echo ${VIM_RESET_VIMRTP})
+    IFS=',' read -ra rtps < <(unset IFS;echo ${vimrtp})
 
     declare -a _rtps
     IFS=',' read -ra _rtps < <(get_vim_rtp)
@@ -315,47 +321,47 @@ vim_deploy() {
         [[ ${rtp} == "~/.vim" ]] && continue
         _rtps=( "${rtp}" "${_rtps[@]}" "${rtp}"/after )
     done
-    VIM_RESET_VIMRTP=$( IFS=","; echo "${_rtps[*]}" )
+    vimrtp=$( IFS=","; echo "${_rtps[*]}" )
 
     echo "========================"
-    echo "VIMRC=${VIM_RESET_VIMRC}"
-    echo "GVIMRC=${VIM_RESET_GVIMRC}"
-    echo "VIMRTP=${VIM_RESET_VIMRTP}"
+    echo "VIMRC=${vimrc}"
+    echo "GVIMRC=${gvimrc}"
+    echo "VIMRTP=${vimrtp}"
     echo "========================"
 
-    if [[ ! -d ${VIM_RESET_CONFDIR}/bin ]]
+    if [[ ! -d ${confdir}/bin ]]
     then
-        mkdir "${VIM_RESET_CONFDIR}/bin"
+        mkdir "${confdir}/bin"
         [[ $? -ne 0 ]] && {
-            echo "Fail to mkdir ${VIM_RESET_CONFDIR}/bin"
+            echo "Fail to mkdir ${confdir}/bin"
             echo "Aborting..."
             return 1
         }
     fi
 
-    cat > "${VIM_RESET_CONFDIR}/bin/vim" <<OUTPUT
+    cat > "${confdir}/bin/vim" <<OUTPUT
 #!/usr/bin/env bash
 # GENERATED_BY_VIM_RESET
 # don't delete the line above
 
-${VIM} --cmd 'set runtimepath=${VIM_RESET_VIMRTP}' -u '${VIM_RESET_VIMRC}' \$@
+${VIM} --cmd 'set runtimepath=${vimrtp}' -u '${vimrc}' \$@
 OUTPUT
 
-    chmod +x "${VIM_RESET_CONFDIR}/bin/vim"
+    chmod +x "${confdir}/bin/vim"
 
-    [[ ! -e ${VIM_RESET_VIMRC} ]] && touch "${VIM_RESET_VIMRC}"
+    [[ ! -e ${vimrc} ]] && touch "${vimrc}"
 
-    cat > "${VIM_RESET_CONFDIR}/bin/gvim" <<OUTPUT
+    cat > "${confdir}/bin/gvim" <<OUTPUT
 #!/usr/bin/env bash
 # GENERATED_BY_VIM_RESET
 # don't delete the line above
 
-${GVIM} --cmd 'set runtimepath=${VIM_RESET_VIMRTP}' -u '${VIM_RESET_VIMRC}' -U '${VIM_RESET_GVIMRC}' \$@
+${GVIM} --cmd 'set runtimepath=${vimrtp}' -u '${vimrc}' -U '${gvimrc}' \$@
 OUTPUT
 
-    chmod +x "${VIM_RESET_CONFDIR}/bin/gvim"
+    chmod +x "${confdir}/bin/gvim"
 
-    [[ ! -e ${VIM_RESET_GVIMRC} ]] && touch "${VIM_RESET_GVIMRC}"
+    [[ ! -e ${gvimrc} ]] && touch "${gvimrc}"
 
     unset VIM_RESET_VIMRC
     unset VIM_RESET_GVIMRC
@@ -365,11 +371,11 @@ OUTPUT
 }
 
 vim_hijack() {
-    if [[ -f ${VIM_RESET_CONFDIR}/bin/vim ]] && [[ -x ${VIM_RESET_CONFDIR}/bin/vim ]]
+    if [[ -f ${confdir}/bin/vim ]] && [[ -x ${confdir}/bin/vim ]]
     then
-        path_push "${VIM_RESET_CONFDIR}/bin"
+        path_push "${confdir}/bin"
     else
-        echo "Something odd has happend, please check ${VIM_RESET_CONFDIR}/bin/vim"
+        echo "Something odd has happend, please check ${confdir}/bin/vim"
         echo "Aborting..."
         return 1
     fi

--- a/activate
+++ b/activate
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-# escape $' \n \t' characters in a string
+#
+# Function: escape
+#
+# Escape $' \n \t' characters in a string.
+#
+# Params:
+#
+#  $1  string to esape
+#
 escape() {
     res=$1
     res=${res// /\\ }
@@ -11,7 +19,15 @@ escape() {
     return 0
 }
 
-# pop $1 from PATH environment variable
+#
+# Function: path_pop
+#
+# Remove a path from 'PATH' environment variable.
+#
+# Params:
+#
+#  $1  path to remove
+#
 path_pop() {
     local path=$1
     local path_array
@@ -19,6 +35,7 @@ path_pop() {
     IFS=':' read -ra path_array <<< "$PATH"
     for path_index in ${!path_array[*]}
     do
+        # Use 'eval' handle tilde expansion
         eval [[ $( escape "${path%/}" ) == $( escape "${path_array[${path_index}]%/}" ) ]] && {
             unset path_array[${path_index}]
         }
@@ -28,7 +45,16 @@ path_pop() {
     return 0
 }
 
-# push $1 as the first directory of PATH environment variable
+#
+# Function: path_push
+#
+# Push a path as the first directory of 'PATH'
+# environment variable.
+#
+# Params:
+#
+#  $1  path to push
+#
 path_push() {
     local path=$1
     path_pop "${path}"
@@ -41,7 +67,7 @@ path_push() {
 # Function: normalize
 #
 # Normalize a given path.
-
+#
 # Do not follow symlink. If the given path is a
 # file, normalize parent directory.
 #
@@ -61,6 +87,11 @@ normalize() {
   return 0
 }
 
+#
+# Function: show_help
+#
+# Show help information.
+#
 show_help() {
     cat << 'EOF'
 
@@ -148,6 +179,11 @@ EOF
 return 0
 }
 
+#
+# Function: vim_reset
+#
+# Main entrance of the whole funcitonality.
+#
 vim_reset() {
     declare -i hard=${VIM_RESET_HARD:-0}
     declare -i force=${VIM_RESET_FORCE:-0}
@@ -197,9 +233,11 @@ vim_reset() {
         shift
     done
 
+    # We don't have 'confdir', might be doing a reverting now.
     if [[ -z ${confdir} ]]
     then
         force=0
+    # When either of these variables is set, that implicates doing a force re-establishing.
     elif [[ ${hard} -eq 1 ]] || [[ -n ${vimrc} ]] || [[ -n ${gvimrc} ]] || [[ -n ${vimrtp} ]]
     then
         force=1
@@ -270,6 +308,11 @@ vim_reset() {
     return 0
 }
 
+#
+# Function: vim_deploy
+#
+# Deploy hijacked vim facility.
+#
 vim_deploy() {
     local VIM=$( which vim )
     [[ -z ${VIM} ]] && {
@@ -386,6 +429,12 @@ OUTPUT
     return 0
 }
 
+#
+# Function: vim_hijack
+#
+# Hijack vim by pushing the path of our vim wrapper as
+# the first directory of 'PATH' env.
+#
 vim_hijack() {
     if [[ -f ${confdir}/bin/vim ]] && [[ -x ${confdir}/bin/vim ]]
     then
@@ -399,6 +448,12 @@ vim_hijack() {
     return 0
 }
 
+#
+# Function: vim_revert
+#
+# Revert any change to the 'PATH' env until we get the
+# original vim back.
+#
 vim_revert() {
     while grep -IF 'GENERATED_BY_VIM_RESET' "$( which vim )" &>/dev/null
     do
@@ -408,7 +463,15 @@ vim_revert() {
     return 0
 }
 
+#
+# Function: git_vim_rtp
+#
+# Get VIM's 'rtp' setting.
+#
 get_vim_rtp() {
+    # ${hard} here is coming from the parent function.
+    # To a invoked child funciton, parent function's local
+    # variable is global.
     if [[ ${hard} -ne 1 ]]
     then
         ${VIM} 2>/dev/null \

--- a/activate
+++ b/activate
@@ -22,6 +22,12 @@ path_push() {
     export PATH=${path}:$PATH
 }
 
+get_vim_rtp() {
+    ${VIM} 2>/dev/null \
+        -c "redir! > /dev/stdout" -c 'set runtimepath' -c 'q' | \
+        tail -n1 | awk -F= '{print $2}' | cut -d, -f2-
+}
+
 # check if vim-reset is already working now
 check_vim_reset() {
     path_push "${VIMCONFIG_DIR}/bin"
@@ -50,14 +56,9 @@ then
     mkdir -p "${VIMCONFIG_DIR}"
 fi
 
-TEMP=$( mktemp )
 VIM=$( which vim )
 
-${VIM} -c "redir! > $TEMP" -c 'set runtimepath' -c 'q'
-
-OLD_RUNTIMEPATH=$( tail -n1 $TEMP | awk -F= '{print $2}' | cut -d, -f2- )
-
-RUNTIMEPATH=${VIMCONFIG_DIR},${OLD_RUNTIMEPATH}
+RUNTIMEPATH=${VIMCONFIG_DIR},$(get_vim_rtp)
 VIMRC=${VIMCONFIG_DIR}/_vimrc
 
 if [[ ! -d ${VIMCONFIG_DIR}/bin ]]

--- a/activate
+++ b/activate
@@ -13,6 +13,8 @@ path_pop() {
         }
     done
     export PATH=$( IFS=":"; echo "${path_array[*]}" )
+
+    return 0
 }
 
 # push $1 as the first directory of PATH environment variable
@@ -20,6 +22,8 @@ path_push() {
     local path=$1
     path_pop "${path}"
     export PATH=$(normalize "${path}"):$PATH
+
+    return 0
 }
 
 #
@@ -42,6 +46,8 @@ normalize() {
     cd "${path}"
   fi
   pwd
+
+  return 0
 }
 
 show_help() {
@@ -127,6 +133,8 @@ Environment Variables:
         Revert the changes made by 'vim-reset'.
 
 EOF
+
+return 0
 }
 
 vim_reset() {
@@ -300,7 +308,9 @@ vim_reset() {
     echo "VIMRTP=${VIM_RESET_VIMRTP}"
     echo "========================"
 
-    hijack_vim || return 1
+    hijack_vim || return $?
+
+    return 0
 }
 
 hijack_vim() {
@@ -355,6 +365,8 @@ OUTPUT
     unset VIM_RESET_VIMRC
     unset VIM_RESET_GVIMRC
     unset VIM_RESET_VIMRTP
+
+    return 0
 }
 
 vim_revert() {
@@ -362,6 +374,8 @@ vim_revert() {
     do
         path_pop "$( dirname $( which vim ) )"
     done
+
+    return 0
 }
 
 get_vim_rtp() {
@@ -375,6 +389,8 @@ get_vim_rtp() {
             -c "redir! > /dev/stdout" -c 'set runtimepath' -c 'q' | \
             tail -n1 | cut -d= -f2-
     fi
+
+    return 0
 }
 
 alias vim-reset=vim_reset

--- a/activate
+++ b/activate
@@ -51,12 +51,19 @@ A bash script so you can customize your very own VIM configurations.
 
 Usage:
 
-    vim-reset [-h|--help]
+    vim-reset [-h|--help] \
+              [--confdir VIM_RESET_CONFDIR]
 
 Options:
 
     -h, --help
         Show this help information.
+
+    --confdir VIM_RESET_CONFDIR
+        The main runtimepath of VIM after the resetting.
+        Either this option or env-variable 'VIM_RESET_CONFDIR' has
+        to been set. If they are both set, the value of this option
+        will be used.
 
 Environment Variables:
 
@@ -89,6 +96,10 @@ vim_reset() {
                 show_help
                 return 0
             ;;
+            --confdir )
+                VIM_RESET_CONFDIR=$2
+                shift
+            ;;
         esac
         shift
     done
@@ -110,7 +121,7 @@ vim_reset() {
 
     if [[ -z ${VIM_RESET_CONFDIR} ]]
     then
-        echo "Env-variable 'VIM_RESET_CONFDIR' has to be set" >&2
+        echo "Either '--confdir' option  or env-variable 'VIM_RESET_CONFDIR' has to be set" >&2
         echo "Aborting..."
         return 1
     else

--- a/activate
+++ b/activate
@@ -334,7 +334,10 @@ hijack_vim() {
 
 ${VIM} --cmd 'set runtimepath=${VIM_RESET_VIMRTP}' -u '${VIM_RESET_VIMRC}' \$@
 OUTPUT
+
         chmod +x "${VIM_RESET_CONFDIR}/bin/vim"
+
+        [[ ! -e ${VIM_RESET_VIMRC} ]] && touch "${VIM_RESET_VIMRC}"
     fi
 
     if [[ ! -e ${VIM_RESET_CONFDIR}/bin/gvim ]] || \
@@ -347,7 +350,10 @@ OUTPUT
 
 ${GVIM} --cmd 'set runtimepath=${VIM_RESET_VIMRTP}' -u '${VIM_RESET_VIMRC}' -U '${VIM_RESET_GVIMRC}' \$@
 OUTPUT
+
         chmod +x "${VIM_RESET_CONFDIR}/bin/gvim"
+
+        [[ ! -e ${VIM_RESET_GVIMRC} ]] && touch "${VIM_RESET_GVIMRC}"
     fi
 
     if [[ -f ${VIM_RESET_CONFDIR}/bin/vim ]] && [[ -x ${VIM_RESET_CONFDIR}/bin/vim ]]
@@ -358,9 +364,6 @@ OUTPUT
         echo "Aborting..."
         return 1
     fi
-
-    [[ ! -e ${VIM_RESET_VIMRC} ]] && touch "${VIM_RESET_VIMRC}"
-    [[ ! -e ${VIM_RESET_GVIMRC} ]] && touch "${VIM_RESET_GVIMRC}"
 
     unset VIM_RESET_VIMRC
     unset VIM_RESET_GVIMRC


### PR DESCRIPTION
嗨，我对 `vim-reset` 进行了大量的改进，也许你有兴趣合并到你的仓库。

由于改进比较多，没有办法就每个特性发起一个 PR，所以打包发送了，希望不要见怪。
- 命令 `vim-reset` 进行真正的的操作，`source vim-reset/active` 只会载入函数到当前环境
- 同时支持环境变量和命令参数的方式调整 `vim-reset` 的行为
- 重命名了各环境变量，以 `VIM_RESET_` 做为前缀避免冲突
- 不再使用全局变量在各个函数之间传递数据
- 不再默认 `./vimconfig`, `VIM_RESET_CONFDIR` 必须设置
- 支持还原 `vim-reset` 的设置
- 支持添加额外的 `rtp` 路径
- 支持 hard reset，即只使用给定的 `rtp` 和系统的 `rtp`
- 支持强制重新 reset
- 正确处理 tilde 展开（`~` 字符展开）
- 劫持 gvim，如果没有 gvim，则 gvim 同 vim
- 如果给定的路径已经有 vim-reset 存在并且非 force，则使用之

你也可以直接从我的仓库拉取。
